### PR TITLE
fix(mcp): 增加与包名同名的 bin，修复 npx sciverse-mcp-server 启动失败

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -17,6 +17,7 @@
   "main": "./dist/server.js",
   "types": "./dist/server.d.ts",
   "bin": {
+    "sciverse-mcp-server": "./dist/cli.js",
     "sciverse-mcp": "./dist/cli.js",
     "sciverse-mcp-http": "./dist/cli-http.js"
   },


### PR DESCRIPTION
`bin` 原本只有 `sciverse-mcp` 与 `sciverse-mcp-http`，两者均不与包名 `sciverse-mcp-server` 同名。`npm exec`/`npx <pkg>` 选 bin 的规则要求要么 有与包名同名的 entry、要么整个 bin 字段唯一，本包两条都不满足，因此
`npx -y sciverse-mcp-server`（Cursor / Claude Desktop 等客户端默认装法） 会抛 `could not determine executable to run`。

增加 `sciverse-mcp-server -> dist/cli.js`（与包名同名、stdio 入口），并 保留旧的 `sciverse-mcp` 别名以兼容已写死命令的现有用户。HTTP 入口
`sciverse-mcp-http` 不变。