### PR TITLE
feat(api): 新增 list_paper_relations tool（论文引用关系分页）

### DIFF
--- a/clawhub/SKILL.md
+++ b/clawhub/SKILL.md
@@ -72,6 +72,20 @@ enum-like fields (OpenSearch terms aggregation, 24h cached).
 
 **Invoke**: `node scripts/list_catalog.mjs '<JSON args>'`
 
+### list_paper_relations
+
+Paginate the full relation list of a paper. citations/references/related_works
+are unbounded arrays (a highly-cited paper can have thousands); search_papers
+only inlines a truncated few, so use this endpoint for the full list.
+Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
+paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
+Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
+are opposite directions.
+Typical chain: get unique_id from search_papers / semantic_search, then paginate
+here by relation.
+
+**Invoke**: `node scripts/list_paper_relations.mjs '<JSON args>'`
+
 ### read_content
 
 Read a UTF-8 byte range of a paper's original text. Typically used with

--- a/clawhub/manifest.json
+++ b/clawhub/manifest.json
@@ -195,6 +195,44 @@
       }
     },
     {
+      "name": "list_paper_relations",
+      "description": "Paginate the full relation list of a paper. citations/references/related_works\nare unbounded arrays (a highly-cited paper can have thousands); search_papers\nonly inlines a truncated few, so use this endpoint for the full list.\nUse when: \"What does paper X cite?\" (relation=REFERENCES), \"Which papers cite\npaper X?\" (relation=CITATIONS), \"Works related to paper X\" (relation=RELATED_WORKS).\nNote: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)\nare opposite directions.\nTypical chain: get unique_id from search_papers / semantic_search, then paginate\nhere by relation.",
+      "script": "scripts/list_paper_relations.mjs",
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "unique_id",
+          "relation"
+        ],
+        "properties": {
+          "unique_id": {
+            "type": "string",
+            "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "CITATIONS",
+              "REFERENCES",
+              "RELATED_WORKS"
+            ],
+            "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+          },
+          "page": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "default": 25,
+            "minimum": 1,
+            "maximum": 200
+          }
+        }
+      }
+    },
+    {
       "name": "read_content",
       "description": "Read a UTF-8 byte range of a paper's original text. Typically used with\na doc_id/offset returned by semantic_search to expand context (read\nmore bytes before or after a chunk).\nReturns: text fragment, bytes_returned, next_offset, more (boolean).",
       "script": "scripts/read_content.mjs",

--- a/dist/anthropic-tools.json
+++ b/dist/anthropic-tools.json
@@ -173,6 +173,43 @@
       }
     },
     {
+      "name": "list_paper_relations",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "input_schema": {
+        "type": "object",
+        "required": [
+          "unique_id",
+          "relation"
+        ],
+        "properties": {
+          "unique_id": {
+            "type": "string",
+            "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "CITATIONS",
+              "REFERENCES",
+              "RELATED_WORKS"
+            ],
+            "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+          },
+          "page": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "default": 25,
+            "minimum": 1,
+            "maximum": 200
+          }
+        }
+      }
+    },
+    {
       "name": "read_content",
       "description": "按字节区间读取文献原文片段。通常配合 semantic_search 返回的 doc_id/offset 使用，\n用于扩展上下文（往前/往后读更多字节）。\n返回：UTF-8 文本片段、bytes_returned、next_offset、是否还有后续。",
       "input_schema": {

--- a/dist/langchain_tools.py
+++ b/dist/langchain_tools.py
@@ -92,6 +92,32 @@ include_sample_values=true 时返回枚举值样本（OpenSearch terms agg，缓
         raise NotImplementedError("bind a client via .with_client(...)")
 
 
+class ListPaperRelationsArgs(BaseModel):
+    model_config = ConfigDict(extra='forbid')
+    unique_id: str = Field(..., description='目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。')
+    relation: str = Field(..., description='关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。')
+    page: int = Field(1, description='')
+    page_size: int = Field(25, description='')
+
+
+class ListPaperRelationsTool(BaseTool):
+    name: str = "list_paper_relations"
+    description: str = """分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
+（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
+（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
+注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
+典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+"""
+    args_schema: type[BaseModel] = ListPaperRelationsArgs
+
+    def _run(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("bind a client via .with_client(...)")
+
+    async def _arun(self, **kwargs: Any) -> Any:
+        raise NotImplementedError("bind a client via .with_client(...)")
+
+
 class ReadContentArgs(BaseModel):
     model_config = ConfigDict(extra='forbid')
     doc_id: str = Field(..., description='文献 ID（来自 search_papers / semantic_search）。')

--- a/dist/openai-tools.json
+++ b/dist/openai-tools.json
@@ -184,6 +184,46 @@
     {
       "type": "function",
       "function": {
+        "name": "list_paper_relations",
+        "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+        "parameters": {
+          "type": "object",
+          "required": [
+            "unique_id",
+            "relation"
+          ],
+          "properties": {
+            "unique_id": {
+              "type": "string",
+              "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+            },
+            "relation": {
+              "type": "string",
+              "enum": [
+                "CITATIONS",
+                "REFERENCES",
+                "RELATED_WORKS"
+              ],
+              "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+            },
+            "page": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 1
+            },
+            "page_size": {
+              "type": "integer",
+              "default": 25,
+              "minimum": 1,
+              "maximum": 200
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
         "name": "read_content",
         "description": "按字节区间读取文献原文片段。通常配合 semantic_search 返回的 doc_id/offset 使用，\n用于扩展上下文（往前/往后读更多字节）。\n返回：UTF-8 文本片段、bytes_returned、next_offset、是否还有后续。",
         "parameters": {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -148,6 +148,82 @@ paths:
         '401': { $ref: '#/components/responses/Unauthorized' }
         '502': { $ref: '#/components/responses/BadGateway' }
 
+  /meta-paper-relations:
+    post:
+      tags: [search]
+      summary: 分页查一篇论文的引用/被引/相关工作列表
+      operationId: list_paper_relations
+      description: |
+        分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
+        （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+        适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
+        （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
+        注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
+        典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+      x-en-summary: Paginate a paper's citations / references / related works
+      x-en-description: |
+        Paginate the full relation list of a paper. citations/references/related_works
+        are unbounded arrays (a highly-cited paper can have thousands); search_papers
+        only inlines a truncated few, so use this endpoint for the full list.
+        Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
+        paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
+        Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
+        are opposite directions.
+        Typical chain: get unique_id from search_papers / semantic_search, then paginate
+        here by relation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [unique_id, relation]
+              properties:
+                unique_id:
+                  type: string
+                  description: 目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。
+                relation:
+                  type: string
+                  enum: [CITATIONS, REFERENCES, RELATED_WORKS]
+                  description: 关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。
+                page:
+                  type: integer
+                  default: 1
+                  minimum: 1
+                page_size:
+                  type: integer
+                  default: 25
+                  minimum: 1
+                  maximum: 200
+      responses:
+        '200':
+          description: 关系列表
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id: { type: string }
+                        id_type: { type: string }
+                        title: { type: string }
+                  total_count: { type: integer }
+                  page: { type: integer }
+                  page_size: { type: integer }
+                  total_pages: { type: integer }
+        '400': { $ref: '#/components/responses/BadRequest' }
+        '401': { $ref: '#/components/responses/Unauthorized' }
+        '404':
+          description: unique_id 对应文档不存在
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ApiError' }
+        '502': { $ref: '#/components/responses/BadGateway' }
+
   /content:
     get:
       tags: [content]

--- a/packages/python/src/sciverse/tools.py
+++ b/packages/python/src/sciverse/tools.py
@@ -188,6 +188,46 @@ OPENAI_TOOLS = json.loads(r"""
   {
     "type": "function",
     "function": {
+      "name": "list_paper_relations",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "parameters": {
+        "type": "object",
+        "required": [
+          "unique_id",
+          "relation"
+        ],
+        "properties": {
+          "unique_id": {
+            "type": "string",
+            "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "CITATIONS",
+              "REFERENCES",
+              "RELATED_WORKS"
+            ],
+            "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+          },
+          "page": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "default": 25,
+            "minimum": 1,
+            "maximum": 200
+          }
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
       "name": "read_content",
       "description": "按字节区间读取文献原文片段。通常配合 semantic_search 返回的 doc_id/offset 使用，\n用于扩展上下文（往前/往后读更多字节）。\n返回：UTF-8 文本片段、bytes_returned、next_offset、是否还有后续。",
       "parameters": {
@@ -408,6 +448,43 @@ ANTHROPIC_TOOLS = json.loads(r"""
         }
       },
       "required": []
+    }
+  },
+  {
+    "name": "list_paper_relations",
+    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+    "input_schema": {
+      "type": "object",
+      "required": [
+        "unique_id",
+        "relation"
+      ],
+      "properties": {
+        "unique_id": {
+          "type": "string",
+          "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+        },
+        "relation": {
+          "type": "string",
+          "enum": [
+            "CITATIONS",
+            "REFERENCES",
+            "RELATED_WORKS"
+          ],
+          "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+        },
+        "page": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "page_size": {
+          "type": "integer",
+          "default": 25,
+          "minimum": 1,
+          "maximum": 200
+        }
+      }
     }
   },
   {

--- a/packages/typescript/src/tools.ts
+++ b/packages/typescript/src/tools.ts
@@ -184,6 +184,46 @@ export const OPENAI_TOOLS = [
   {
     "type": "function",
     "function": {
+      "name": "list_paper_relations",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "parameters": {
+        "type": "object",
+        "required": [
+          "unique_id",
+          "relation"
+        ],
+        "properties": {
+          "unique_id": {
+            "type": "string",
+            "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "CITATIONS",
+              "REFERENCES",
+              "RELATED_WORKS"
+            ],
+            "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+          },
+          "page": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "default": 25,
+            "minimum": 1,
+            "maximum": 200
+          }
+        }
+      }
+    }
+  },
+  {
+    "type": "function",
+    "function": {
       "name": "read_content",
       "description": "按字节区间读取文献原文片段。通常配合 semantic_search 返回的 doc_id/offset 使用，\n用于扩展上下文（往前/往后读更多字节）。\n返回：UTF-8 文本片段、bytes_returned、next_offset、是否还有后续。",
       "parameters": {
@@ -401,6 +441,43 @@ export const ANTHROPIC_TOOLS = [
         }
       },
       "required": []
+    }
+  },
+  {
+    "name": "list_paper_relations",
+    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+    "input_schema": {
+      "type": "object",
+      "required": [
+        "unique_id",
+        "relation"
+      ],
+      "properties": {
+        "unique_id": {
+          "type": "string",
+          "description": "目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。"
+        },
+        "relation": {
+          "type": "string",
+          "enum": [
+            "CITATIONS",
+            "REFERENCES",
+            "RELATED_WORKS"
+          ],
+          "description": "关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。"
+        },
+        "page": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 1
+        },
+        "page_size": {
+          "type": "integer",
+          "default": 25,
+          "minimum": 1,
+          "maximum": 200
+        }
+      }
     }
   },
   {

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -40,6 +40,18 @@ export interface paths {
      */
     get: operations["list_catalog"];
   };
+  "/meta-paper-relations": {
+    /**
+     * 分页查一篇论文的引用/被引/相关工作列表
+     * @description 分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
+     * （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+     * 适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
+     * （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
+     * 注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
+     * 典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+     */
+    post: operations["list_paper_relations"];
+  };
   "/content": {
     /**
      * 按字节区间读取文献原文片段
@@ -335,6 +347,61 @@ export interface operations {
         };
       };
       401: components["responses"]["Unauthorized"];
+      502: components["responses"]["BadGateway"];
+    };
+  };
+  /**
+   * 分页查一篇论文的引用/被引/相关工作列表
+   * @description 分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
+   * （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+   * 适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
+   * （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
+   * 注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
+   * 典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+   */
+  list_paper_relations: {
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description 目标论文 unique_id（如 paper:10.1038/xxx），来自 search_papers / semantic_search；勿传 doc_id。 */
+          unique_id: string;
+          /**
+           * @description 关系类型。CITATIONS=被引（谁引用了我）；REFERENCES=参考文献（我引用了谁）；RELATED_WORKS=相关工作。
+           * @enum {string}
+           */
+          relation: "CITATIONS" | "REFERENCES" | "RELATED_WORKS";
+          /** @default 1 */
+          page?: number;
+          /** @default 25 */
+          page_size?: number;
+        };
+      };
+    };
+    responses: {
+      /** @description 关系列表 */
+      200: {
+        content: {
+          "application/json": {
+            items?: {
+                id?: string;
+                id_type?: string;
+                title?: string;
+              }[];
+            total_count?: number;
+            page?: number;
+            page_size?: number;
+            total_pages?: number;
+          };
+        };
+      };
+      400: components["responses"]["BadRequest"];
+      401: components["responses"]["Unauthorized"];
+      /** @description unique_id 对应文档不存在 */
+      404: {
+        content: {
+          "application/json": components["schemas"]["ApiError"];
+        };
+      };
       502: components["responses"]["BadGateway"];
     };
   };

--- a/skill-claude-code/SKILL.md
+++ b/skill-claude-code/SKILL.md
@@ -99,6 +99,18 @@ from the returned schema.
 Pass include_sample_values=true to also fetch top-20 values for
 enum-like fields (OpenSearch terms aggregation, 24h cached).
 
+### list_paper_relations
+
+Paginate the full relation list of a paper. citations/references/related_works
+are unbounded arrays (a highly-cited paper can have thousands); search_papers
+only inlines a truncated few, so use this endpoint for the full list.
+Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
+paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
+Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
+are opposite directions.
+Typical chain: get unique_id from search_papers / semantic_search, then paginate
+here by relation.
+
 ### read_content
 
 Read a UTF-8 byte range of a paper's original text. Typically used with


### PR DESCRIPTION
对应 platform-console POST /meta-paper-relations：分页查一篇论文的 citations/references/related_works 完整列表（search_papers 只内联截断少量）。 description 写明用途、relation 枚举（CITATIONS=被引 vs REFERENCES=参考文献 方向相反）、典型链路（先拿 unique_id 再翻页），中英双描述。重新生成全部
派生产物（dist tools、Python/TS SDK、clawhub/claude-code skill）。