### PR TITLE
feat: 引文反查能力与 relations 契约变更同步，0.8.1 → 0.9.0

### DIFF
--- a/clawhub/SKILL.md
+++ b/clawhub/SKILL.md
@@ -75,14 +75,20 @@ enum-like fields (OpenSearch terms aggregation, 24h cached).
 ### list_paper_relations
 
 Paginate the full relation list of a paper. citations/references/related_works
-are unbounded arrays (a highly-cited paper can have thousands); search_papers
-only inlines a truncated few, so use this endpoint for the full list.
+are unbounded arrays (up to 340k entries for a single paper) and are NOT
+projectable in search_papers, so this endpoint is the only way to read them.
 Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
 paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
 Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
 are opposite directions.
 Typical chain: get unique_id from search_papers / semantic_search, then paginate
 here by relation.
+Two limits (CITATIONS only; REFERENCES/RELATED_WORKS max out at 11833/20 in practice):
+more than 10000 relations returns 429; page*page_size above 10000 returns 400.
+In both cases switch to search_papers with filters_advanced on
+references_unique_id — it supports deep paging and arbitrary sorting.
+total_count counts in-corpus matches only, so it can differ from the paper's own
+citation_count by about 1%.
 
 **Invoke**: `node scripts/list_paper_relations.mjs '<JSON args>'`
 

--- a/clawhub/manifest.json
+++ b/clawhub/manifest.json
@@ -81,7 +81,7 @@
           },
           "filters_advanced": {
             "type": "array",
-            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
             "items": {
               "type": "object",
               "required": [
@@ -249,7 +249,7 @@
     },
     {
       "name": "list_paper_relations",
-      "description": "Paginate the full relation list of a paper. citations/references/related_works\nare unbounded arrays (a highly-cited paper can have thousands); search_papers\nonly inlines a truncated few, so use this endpoint for the full list.\nUse when: \"What does paper X cite?\" (relation=REFERENCES), \"Which papers cite\npaper X?\" (relation=CITATIONS), \"Works related to paper X\" (relation=RELATED_WORKS).\nNote: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)\nare opposite directions.\nTypical chain: get unique_id from search_papers / semantic_search, then paginate\nhere by relation.",
+      "description": "Paginate the full relation list of a paper. citations/references/related_works\nare unbounded arrays (up to 340k entries for a single paper) and are NOT\nprojectable in search_papers, so this endpoint is the only way to read them.\nUse when: \"What does paper X cite?\" (relation=REFERENCES), \"Which papers cite\npaper X?\" (relation=CITATIONS), \"Works related to paper X\" (relation=RELATED_WORKS).\nNote: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)\nare opposite directions.\nTypical chain: get unique_id from search_papers / semantic_search, then paginate\nhere by relation.\nTwo limits (CITATIONS only; REFERENCES/RELATED_WORKS max out at 11833/20 in practice):\nmore than 10000 relations returns 429; page*page_size above 10000 returns 400.\nIn both cases switch to search_papers with filters_advanced on\nreferences_unique_id — it supports deep paging and arbitrary sorting.\ntotal_count counts in-corpus matches only, so it can differ from the paper's own\ncitation_count by about 1%.",
       "script": "scripts/list_paper_relations.mjs",
       "input_schema": {
         "type": "object",

--- a/dist/anthropic-tools.json
+++ b/dist/anthropic-tools.json
@@ -61,7 +61,7 @@
           },
           "filters_advanced": {
             "type": "array",
-            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
             "items": {
               "type": "object",
               "required": [
@@ -227,7 +227,7 @@
     },
     {
       "name": "list_paper_relations",
-      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
       "input_schema": {
         "type": "object",
         "required": [

--- a/dist/langchain_tools.py
+++ b/dist/langchain_tools.py
@@ -20,7 +20,7 @@ class SearchPapersArgs(BaseModel):
     year_to: int | None = Field(None, description='结束发表年（含）。')
     journals: list[str] | None = Field(None, description='期刊名（任一命中即可）。SDK 内部映射到后端 `publication_venue_name_unified` 字段（FILTER_OP_IN，规范化后的载体名）。')
     subjects: list[str] | None = Field(None, description='学科分类，如 "computer science"、"biology"。')
-    filters_advanced: list[dict[str, Any]] | None = Field(None, description='高级过滤逃生舱（仅当上述字段不够用时使用）。')
+    filters_advanced: list[dict[str, Any]] | None = Field(None, description='高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field="references_unique_id" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{"field":"references_unique_id","value":"paper:10.1109/cvpr.2016.90"},\n   {"field":"publication_published_year","operator":"FILTER_OP_GTE","value":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n')
     sort_advanced: list[dict[str, Any]] | None = Field(None, description='高级排序逃生舱（按任意可排序字段）。papers 用 sort_by_year 即可； authors/sources 想按 h-index / 被引 / works_count 排序时用本字段。 与 query 互斥（query 走相关性排序）。')
     sort_by_year: str = Field('desc', description='')
     freshness_boost: str = Field('NONE', description='模糊搜索新鲜度加权（仅 query 非空时生效；与 sort_by_year 互斥）。\nMILD: 近 10 年加权，适合日常查文献；STRONG: 近 3 年加权，适合跟踪\n研究方向 / 追最新进展。底层为 function_score + gauss decay over\npublication_published_date。\n')
@@ -107,11 +107,15 @@ class ListPaperRelationsArgs(BaseModel):
 class ListPaperRelationsTool(BaseTool):
     name: str = "list_paper_relations"
     description: str = """分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
-（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。
 适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
 （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
 注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
 典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：
+关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用
+search_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。
+total_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。
 """
     args_schema: type[BaseModel] = ListPaperRelationsArgs
 

--- a/dist/openai-tools.json
+++ b/dist/openai-tools.json
@@ -63,7 +63,7 @@
             },
             "filters_advanced": {
               "type": "array",
-              "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+              "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
               "items": {
                 "type": "object",
                 "required": [
@@ -238,7 +238,7 @@
       "type": "function",
       "function": {
         "name": "list_paper_relations",
-        "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+        "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
         "parameters": {
           "type": "object",
           "required": [

--- a/generators/web_skill_assets/references/search-tools.md
+++ b/generators/web_skill_assets/references/search-tools.md
@@ -53,8 +53,25 @@ Common arguments:
 
 ## list_paper_relations
 
-Paginate a paper's full citations / references / related works. `search_papers` only
-inlines a truncated few of these unbounded arrays, so use this for the complete list.
+Paginate a paper's full citations / references / related works. These are unbounded
+arrays (up to 340k entries) and are **not projectable** in `search_papers`, so this
+endpoint is the only way to read them.
+
+**Limits (CITATIONS only)**: over 10000 relations returns 429; `page * page_size`
+above 10000 returns 400. In both cases switch to reverse lookup via `search_papers`:
+
+```bash
+node scripts/search_papers.mjs '{
+  "filters_advanced": [
+    {"field": "references_unique_id", "value": "paper:10.1109/cvpr.2016.90"}
+  ],
+  "sort_advanced": [{"field": "citation_count", "order": "SORT_ORDER_DESC"}],
+  "page_size": 50
+}'
+```
+
+`total_count` counts in-corpus matches only, so it can differ from the paper's own
+`citation_count` by about 1%.
 
 ```bash
 node scripts/list_paper_relations.mjs '{

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -165,22 +165,32 @@ paths:
       operationId: list_paper_relations
       description: |
         分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
-        （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+        （单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。
         适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
         （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
         注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
         典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+        两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：
+        关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用
+        search_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。
+        total_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。
       x-en-summary: Paginate a paper's citations / references / related works
       x-en-description: |
         Paginate the full relation list of a paper. citations/references/related_works
-        are unbounded arrays (a highly-cited paper can have thousands); search_papers
-        only inlines a truncated few, so use this endpoint for the full list.
+        are unbounded arrays (up to 340k entries for a single paper) and are NOT
+        projectable in search_papers, so this endpoint is the only way to read them.
         Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
         paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
         Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
         are opposite directions.
         Typical chain: get unique_id from search_papers / semantic_search, then paginate
         here by relation.
+        Two limits (CITATIONS only; REFERENCES/RELATED_WORKS max out at 11833/20 in practice):
+        more than 10000 relations returns 429; page*page_size above 10000 returns 400.
+        In both cases switch to search_papers with filters_advanced on
+        references_unique_id — it supports deep paging and arbitrary sorting.
+        total_count counts in-corpus matches only, so it can differ from the paper's own
+        citation_count by about 1%.
       requestBody:
         required: true
         content:
@@ -368,7 +378,16 @@ components:
           description: 学科分类，如 "computer science"、"biology"。
         filters_advanced:
           type: array
-          description: 高级过滤逃生舱（仅当上述字段不够用时使用）。
+          description: |
+            高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。
+
+            引文反查（常用）：field="references_unique_id" 查「谁引用了某篇论文」，
+            value 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，
+            它支持深翻页与任意排序，适合超高被引论文。可叠加条件，
+            例如「引用了 ResNet 且 2023 年后发表」：
+              [{"field":"references_unique_id","value":"paper:10.1109/cvpr.2016.90"},
+               {"field":"publication_published_year","operator":"FILTER_OP_GTE","value":2023}]
+            该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。
           items:
             type: object
             required: [field, value]

--- a/packages/python/src/sciverse/tools.py
+++ b/packages/python/src/sciverse/tools.py
@@ -67,7 +67,7 @@ OPENAI_TOOLS = json.loads(r"""
           },
           "filters_advanced": {
             "type": "array",
-            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
             "items": {
               "type": "object",
               "required": [
@@ -242,7 +242,7 @@ OPENAI_TOOLS = json.loads(r"""
     "type": "function",
     "function": {
       "name": "list_paper_relations",
-      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
       "parameters": {
         "type": "object",
         "required": [
@@ -392,7 +392,7 @@ ANTHROPIC_TOOLS = json.loads(r"""
         },
         "filters_advanced": {
           "type": "array",
-          "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+          "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
           "items": {
             "type": "object",
             "required": [
@@ -558,7 +558,7 @@ ANTHROPIC_TOOLS = json.loads(r"""
   },
   {
     "name": "list_paper_relations",
-    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
     "input_schema": {
       "type": "object",
       "required": [

--- a/packages/python/src/sciverse/types.py
+++ b/packages/python/src/sciverse/types.py
@@ -105,7 +105,8 @@ class SearchPapersRequest(BaseModel):
         None, description='学科分类，如 "computer science"、"biology"。'
     )
     filters_advanced: list[FiltersAdvancedItem] | None = Field(
-        None, description="高级过滤逃生舱（仅当上述字段不够用时使用）。"
+        None,
+        description='高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field="references_unique_id" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{"field":"references_unique_id","value":"paper:10.1109/cvpr.2016.90"},\n   {"field":"publication_published_year","operator":"FILTER_OP_GTE","value":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n',
     )
     sort_advanced: list[SortAdvancedItem] | None = Field(
         None,

--- a/packages/typescript/src/tools.ts
+++ b/packages/typescript/src/tools.ts
@@ -63,7 +63,7 @@ export const OPENAI_TOOLS = [
           },
           "filters_advanced": {
             "type": "array",
-            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+            "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
             "items": {
               "type": "object",
               "required": [
@@ -238,7 +238,7 @@ export const OPENAI_TOOLS = [
     "type": "function",
     "function": {
       "name": "list_paper_relations",
-      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+      "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
       "parameters": {
         "type": "object",
         "required": [
@@ -385,7 +385,7 @@ export const ANTHROPIC_TOOLS = [
         },
         "filters_advanced": {
           "type": "array",
-          "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。",
+          "description": "高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。\n\n引文反查（常用）：field=\"references_unique_id\" 查「谁引用了某篇论文」，\nvalue 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，\n它支持深翻页与任意排序，适合超高被引论文。可叠加条件，\n例如「引用了 ResNet 且 2023 年后发表」：\n  [{\"field\":\"references_unique_id\",\"value\":\"paper:10.1109/cvpr.2016.90\"},\n   {\"field\":\"publication_published_year\",\"operator\":\"FILTER_OP_GTE\",\"value\":2023}]\n该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。\n",
           "items": {
             "type": "object",
             "required": [
@@ -551,7 +551,7 @@ export const ANTHROPIC_TOOLS = [
   },
   {
     "name": "list_paper_relations",
-    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。",
+    "description": "分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组\n（单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。\n适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」\n（relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。\n注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。\n典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。\n两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：\n关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用\nsearch_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。\ntotal_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。",
     "input_schema": {
       "type": "object",
       "required": [

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -44,11 +44,15 @@ export interface paths {
     /**
      * 分页查一篇论文的引用/被引/相关工作列表
      * @description 分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
-     * （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+     * （单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。
      * 适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
      * （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
      * 注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
      * 典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+     * 两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：
+     * 关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用
+     * search_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。
+     * total_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。
      */
     post: operations["list_paper_relations"];
   };
@@ -102,7 +106,17 @@ export interface components {
       journals?: string[];
       /** @description 学科分类，如 "computer science"、"biology"。 */
       subjects?: string[];
-      /** @description 高级过滤逃生舱（仅当上述字段不够用时使用）。 */
+      /**
+       * @description 高级过滤逃生舱（仅当上述字段不够用时使用）。可用字段见 get_field_catalog。
+       *
+       * 引文反查（常用）：field="references_unique_id" 查「谁引用了某篇论文」，
+       * value 填目标论文的 unique_id。相比 list_paper_relations 的 CITATIONS，
+       * 它支持深翻页与任意排序，适合超高被引论文。可叠加条件，
+       * 例如「引用了 ResNet 且 2023 年后发表」：
+       *   [{"field":"references_unique_id","value":"paper:10.1109/cvpr.2016.90"},
+       *    {"field":"publication_published_year","operator":"FILTER_OP_GTE","value":2023}]
+       * 该字段仅支持过滤，不能排序/聚合，也不能放进 fields 返回。
+       */
       filters_advanced?: ({
           field: string;
           /**
@@ -393,11 +407,15 @@ export interface operations {
   /**
    * 分页查一篇论文的引用/被引/相关工作列表
    * @description 分页返回某篇论文的引用关系完整列表。citations/references/related_works 是无界数组
-   * （高被引文献可达数千条），search_papers 只内联截断少量，要翻完整列表用本接口。
+   * （单篇最大 34 万条），在 search_papers 中**不可投影**，取这些列表只能用本接口。
    * 适用：「论文 X 引用了哪些文献」（relation=REFERENCES）、「哪些文献引用了论文 X」
    * （relation=CITATIONS）、「与论文 X 相关的工作」（relation=RELATED_WORKS）。
    * 注意：CITATIONS（被引：谁引用了我）与 REFERENCES（参考文献：我引用了谁）方向相反。
    * 典型链路：先 search_papers / semantic_search 拿到 unique_id，再用本接口按 relation 分页。
+   * 两个上限（仅 CITATIONS 可能触发；REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：
+   * 关系数超 10000 返回 429；page×page_size 超 10000 返回 400。两种情况都改用
+   * search_papers 的 filters_advanced 传 references_unique_id 反查——可深翻页并任意排序。
+   * total_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。
    */
   list_paper_relations: {
     requestBody: {

--- a/skill-claude-code/SKILL.md
+++ b/skill-claude-code/SKILL.md
@@ -103,14 +103,20 @@ enum-like fields (OpenSearch terms aggregation, 24h cached).
 ### list_paper_relations
 
 Paginate the full relation list of a paper. citations/references/related_works
-are unbounded arrays (a highly-cited paper can have thousands); search_papers
-only inlines a truncated few, so use this endpoint for the full list.
+are unbounded arrays (up to 340k entries for a single paper) and are NOT
+projectable in search_papers, so this endpoint is the only way to read them.
 Use when: "What does paper X cite?" (relation=REFERENCES), "Which papers cite
 paper X?" (relation=CITATIONS), "Works related to paper X" (relation=RELATED_WORKS).
 Note: CITATIONS (incoming: who cites me) and REFERENCES (outgoing: who I cite)
 are opposite directions.
 Typical chain: get unique_id from search_papers / semantic_search, then paginate
 here by relation.
+Two limits (CITATIONS only; REFERENCES/RELATED_WORKS max out at 11833/20 in practice):
+more than 10000 relations returns 429; page*page_size above 10000 returns 400.
+In both cases switch to search_papers with filters_advanced on
+references_unique_id — it supports deep paging and arbitrary sorting.
+total_count counts in-corpus matches only, so it can differ from the paper's own
+citation_count by about 1%.
 
 ### read_content
 


### PR DESCRIPTION
metadata-service 侧本次变更需要在契约层同步（openapi.yaml 为单一真相源， 中英双语描述同改）：

1. list_paper_relations 描述更正 原文"search_papers 只内联截断少量"已过时——citations/references/related_works 现在在 search_papers 中【完全不可投影】（无界数组，投影会随 page_size 倍增， 实测 page_size=5 即数百 MB），取这些列表只能用本接口。 补充两个上限（仅 CITATIONS 可能触发，REFERENCES/RELATED_WORKS 实测最大 11833/20 条）：关系数超 10000 返回 429；page×page_size 超 10000 返回 400。 两种情况都引导改用 references_unique_id 反查。 补充 total_count 口径：库内命中数，与论文自身 citation_count 有 ±1% 差异。

2. filters_advanced 暴露引文反查 field="references_unique_id" 查「谁引用了某篇论文」。相比 CITATIONS 关系接口， 它支持深翻页与任意排序，适合超高被引论文。给出叠加过滤示例，并声明该字段 只能过滤、不能排序/聚合/投影。

3. web skill 静态资源同步（generators/web_skill_assets/references/search-tools.md 是手写源文件，不由 openapi 派生，需单独更新），补可直接执行的反查示例。

跑 scripts/build.sh 重新生成全部派生产物：dist/*.json、python/typescript SDK、 clawhub skill、claude-code skill、marketplace、web-skill.tgz。

版本号：clawhub/manifest.json 的 version 由生成器有意与 SDK 脱钩（支持 skill 独立 bump），故 build 后仍停在 0.8.1，已手动对齐到 0.9.0 并重新生成。
四处产物版本现均为 0.9.0。self-check OK，36 tests pass。

⚠️ 发布时序：references_unique_id 需 metadata-service 的
feat/smart-cn-and-synonym 合并且索引切换后才可用，本包发布应晚于该能力上线。