### PR TITLE
feat: HTTP 入口鉴权双通道（可信 IP + Authorization 透传）与请求日志

### DIFF
--- a/packages/mcp/src/cli-http.ts
+++ b/packages/mcp/src/cli-http.ts
@@ -7,8 +7,9 @@
 //      session id 由 SDK 在 initialize 阶段通过 crypto.randomUUID() 分配，
 //      存到内存 Map，容器重启即清空。Phase 1 单副本部署可接受。
 //   3. 鉴权双通道（Phase 1.5，http-auth.ts）：Authorization: Bearer 透传（channel
-//      "remote"）或来源 IP ∈ SCP Hub 白名单走内置 token（channel 沿用配置）；
+//      "remote"）或来源 IP ∈ 可信 IP 白名单走内置 token（channel 沿用配置）；
 //      两者皆无 → 401。session 与首次判定的凭据绑定，后续请求不一致同样 401。
+//      XFF 仅在 TCP 对端命中信任代理网段时采信（默认永不），防直连伪造。
 //   4. /healthz 返回 200 纯文本，供 K8s readiness/liveness probe 使用（不鉴权、不记日志）。
 //   5. 配置错误 (loadConfig 抛 ConfigError) 时 stderr 输出并 exit(2)，
 //      与 cli.ts 行为一致。
@@ -295,15 +296,16 @@ async function main(): Promise<void> {
   }
 
   const auth = loadAuthOptions();
-  if (auth.hubIps.size === 0) {
+  if (auth.trustedIps.size === 0) {
     process.stderr.write(
-      "[sciverse-mcp] SCP_HUB_IPS 未配置：hub 通道关闭，所有请求都需要 Authorization\n",
+      "[sciverse-mcp] SCIVERSE_MCP_TRUSTED_IPS 未配置：可信 IP 通道关闭，所有请求都需要 Authorization\n",
     );
   }
   const handle = await startHttpServer(config, { port, auth });
+  const proxyCount = auth.trustedProxies.v4.length + auth.trustedProxies.exact.size;
   process.stderr.write(
     `[sciverse-mcp] listening on :${handle.port}${MCP_PATH} ` +
-      `(hub_ips=${auth.hubIps.size} trusted_hops=${auth.trustedHops})\n`,
+      `(trusted_ips=${auth.trustedIps.size} trusted_proxies=${proxyCount} hops=${auth.trustedHops})\n`,
   );
 
   // 收到信号时优雅退出

--- a/packages/mcp/src/cli-http.ts
+++ b/packages/mcp/src/cli-http.ts
@@ -6,11 +6,14 @@
 //   2. 每个 MCP session 独立一份 Server + Transport，避免不同会话间状态串扰；
 //      session id 由 SDK 在 initialize 阶段通过 crypto.randomUUID() 分配，
 //      存到内存 Map，容器重启即清空。Phase 1 单副本部署可接受。
-//   3. 边缘信任模型：本进程不校验 SCP-HUB-API-KEY，由 Ingress IP 白名单兜底；
-//      Phase 1.5 再补 header 校验。
-//   4. /healthz 返回 200 纯文本，供 K8s readiness/liveness probe 使用。
+//   3. 鉴权双通道（Phase 1.5，http-auth.ts）：Authorization: Bearer 透传（channel
+//      "remote"）或来源 IP ∈ SCP Hub 白名单走内置 token（channel 沿用配置）；
+//      两者皆无 → 401。session 与首次判定的凭据绑定，后续请求不一致同样 401。
+//   4. /healthz 返回 200 纯文本，供 K8s readiness/liveness probe 使用（不鉴权、不记日志）。
 //   5. 配置错误 (loadConfig 抛 ConfigError) 时 stderr 输出并 exit(2)，
 //      与 cli.ts 行为一致。
+//   6. 每个 /mcp 请求向 stdout 写一行结构化日志（SLS 经 aliyun_logs_app_logs=stdout
+//      采集）；恒不落 token。
 import { randomUUID } from "node:crypto";
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "node:http";
 
@@ -18,6 +21,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 
 import { ConfigError, loadConfig, type Config } from "./config.js";
+import { loadAuthOptions, resolveLane, type AuthOptions, type Lane } from "./http-auth.js";
 import { createServer } from "./server.js";
 
 const DEFAULT_PORT = 8080;
@@ -64,38 +68,95 @@ export interface HttpServerHandle {
   close: () => Promise<void>;
 }
 
+// 每请求日志的可变元信息：handleMcp 边处理边填，响应关闭时统一写一行。
+interface ReqLogMeta {
+  lane: Lane | "anon";
+  rpc: string;
+  session: string;
+}
+
+// 从 JSON-RPC payload 提取方法名（batch 用 + 连接），仅用于日志。
+function rpcMethodOf(body: unknown): string {
+  if (Array.isArray(body)) {
+    const names = body
+      .map((m) => (m && typeof m === "object" ? (m as { method?: string }).method : undefined))
+      .filter((s): s is string => typeof s === "string");
+    return names.length > 0 ? names.join("+") : "batch";
+  }
+  if (body && typeof body === "object") {
+    const method = (body as { method?: unknown }).method;
+    if (typeof method === "string") return method;
+  }
+  return "-";
+}
+
+function writeUnauthorized(res: ServerResponse): void {
+  res.setHeader("www-authenticate", "Bearer");
+  writeJsonRpcError(
+    res,
+    401,
+    "Unauthorized: provide `Authorization: Bearer <sciverse token>` (get one at https://sciverse.space)",
+  );
+}
+
 // 启动 HTTP server，返回句柄。导出供测试复用，避免 spawn 子进程。
 export async function startHttpServer(
   config: Config,
-  options: { port?: number; host?: string } = {},
+  options: { port?: number; host?: string; auth?: AuthOptions } = {},
 ): Promise<HttpServerHandle> {
   const port = options.port ?? DEFAULT_PORT;
   const host = options.host ?? "0.0.0.0";
+  const auth = options.auth ?? loadAuthOptions();
 
-  // session id → { transport, server } 映射。Phase 1 进程内 Map 即可。
+  // session id → transport + 首次判定的凭据（lane/token 绑定，防 session id 被盗用）。
   const sessions = new Map<
     string,
-    { transport: StreamableHTTPServerTransport; close: () => Promise<void> }
+    {
+      transport: StreamableHTTPServerTransport;
+      close: () => Promise<void>;
+      lane: Lane;
+      token: string;
+    }
   >();
 
-  const handleMcp = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+  const handleMcp = async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    meta: ReqLogMeta,
+  ): Promise<void> => {
     const method = req.method ?? "GET";
     const sessionId = req.headers["mcp-session-id"];
     const sessionIdStr = Array.isArray(sessionId) ? sessionId[0] : sessionId;
+    if (sessionIdStr) meta.session = sessionIdStr.slice(0, 8);
+
+    // 鉴权判定先于一切处理；不通过的请求不进 MCP 协议层。
+    const decision = resolveLane(req, config, auth);
+    if (!decision) {
+      writeUnauthorized(res);
+      return;
+    }
+    meta.lane = decision.lane;
+
+    // 复用 session 时校验凭据与首次判定一致；不一致按未授权处理（不泄露 session 存在性）。
+    const boundEntry = sessionIdStr ? sessions.get(sessionIdStr) : undefined;
+    if (boundEntry && (boundEntry.lane !== decision.lane || boundEntry.token !== decision.token)) {
+      writeUnauthorized(res);
+      return;
+    }
 
     // POST：初始化 or 后续 JSON-RPC 调用
     if (method === "POST") {
       const raw = await readBody(req);
       const body = parseJsonBody(raw);
+      meta.rpc = rpcMethodOf(body);
 
       // 已有 session：复用 transport
-      if (sessionIdStr && sessions.has(sessionIdStr)) {
-        const entry = sessions.get(sessionIdStr)!;
-        await entry.transport.handleRequest(req, res, body);
+      if (boundEntry) {
+        await boundEntry.transport.handleRequest(req, res, body);
         return;
       }
 
-      // 无 session + 是 initialize：新建 transport + Server
+      // 无 session + 是 initialize：新建 transport + Server（携带本 session 的凭据）
       if (!sessionIdStr && isInitializeRequest(body)) {
         const transport = new StreamableHTTPServerTransport({
           sessionIdGenerator: () => randomUUID(),
@@ -103,6 +164,8 @@ export async function startHttpServer(
             // 在 initialize 完成时把 transport 注册进表；规避请求先于 sessionId 落表的竞态。
             sessions.set(sid, {
               transport,
+              lane: decision.lane,
+              token: decision.token,
               close: async () => {
                 await transport.close();
                 await server.close();
@@ -116,7 +179,8 @@ export async function startHttpServer(
             sessions.delete(sid);
           }
         };
-        const server = createServer(config);
+        // 每 session 一份 config：token/channel 来自通道判定，其余沿用进程配置。
+        const server = createServer({ ...config, token: decision.token, channel: decision.channel });
         await server.connect(transport);
         await transport.handleRequest(req, res, body);
         return;
@@ -129,14 +193,13 @@ export async function startHttpServer(
 
     // GET (SSE 长轮询) / DELETE (session 终止)：必须带 session id
     if (method === "GET" || method === "DELETE") {
-      if (!sessionIdStr || !sessions.has(sessionIdStr)) {
+      if (!boundEntry) {
         res.statusCode = 400;
         res.setHeader("content-type", "text/plain");
         res.end("Invalid or missing session ID");
         return;
       }
-      const entry = sessions.get(sessionIdStr)!;
-      await entry.transport.handleRequest(req, res);
+      await boundEntry.transport.handleRequest(req, res);
       return;
     }
 
@@ -155,7 +218,17 @@ export async function startHttpServer(
       return;
     }
     if (url === MCP_PATH || url.startsWith(`${MCP_PATH}?`) || url.startsWith(`${MCP_PATH}/`)) {
-      handleMcp(req, res).catch((err) => {
+      const startedAt = Date.now();
+      const meta: ReqLogMeta = { lane: "anon", rpc: "-", session: "-" };
+      // "close" 同时覆盖正常结束与客户端中断；一行 key=value 结构化日志（恒不含 token）。
+      res.once("close", () => {
+        process.stdout.write(
+          `[sciverse-mcp] req method=${req.method ?? "-"} path=${MCP_PATH} rpc=${meta.rpc} ` +
+            `lane=${meta.lane} session=${meta.session} status=${res.statusCode} ` +
+            `dur_ms=${Date.now() - startedAt}\n`,
+        );
+      });
+      handleMcp(req, res, meta).catch((err) => {
         process.stderr.write(
           `[sciverse-mcp] handleRequest error: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
         );
@@ -221,8 +294,17 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  const handle = await startHttpServer(config, { port });
-  process.stderr.write(`[sciverse-mcp] listening on :${handle.port}${MCP_PATH}\n`);
+  const auth = loadAuthOptions();
+  if (auth.hubIps.size === 0) {
+    process.stderr.write(
+      "[sciverse-mcp] SCP_HUB_IPS 未配置：hub 通道关闭，所有请求都需要 Authorization\n",
+    );
+  }
+  const handle = await startHttpServer(config, { port, auth });
+  process.stderr.write(
+    `[sciverse-mcp] listening on :${handle.port}${MCP_PATH} ` +
+      `(hub_ips=${auth.hubIps.size} trusted_hops=${auth.trustedHops})\n`,
+  );
 
   // 收到信号时优雅退出
   const shutdown = async (signal: string): Promise<void> => {

--- a/packages/mcp/src/http-auth.ts
+++ b/packages/mcp/src/http-auth.ts
@@ -1,0 +1,88 @@
+// 双通道鉴权判定器（sciverse-console: docs/plans/2026-05-19-scp-mcp-http-transport.md §8.2）：
+//   direct 通道：Authorization: Bearer <token> → 原样透传下游，channel = "remote"
+//   hub 通道：来源 IP ∈ SCP_HUB_IPS（信任跳 XFF 判定）→ 使用部署内置 token 代调
+//   两者皆无 → 调用方返回 401
+//
+// Authorization 优先于 IP：自带 token 是比来源 IP 更明确的身份声明，且计费归属
+// 到调用方自己；Hub 将来若支持配转发 header，可无缝升级为自带 token。
+// 判定器刻意独立成模块：替换 hub 分支即可切换判定策略，透传通道不动。
+import type { IncomingMessage } from "node:http";
+
+import type { Config } from "./config.js";
+
+export type Lane = "hub" | "direct";
+
+export interface LaneDecision {
+  lane: Lane;
+  token: string;
+  channel: string;
+}
+
+export interface AuthOptions {
+  /** SCP Hub 出口 IP（精确匹配，已归一化）。空集 = hub 通道关闭。 */
+  hubIps: Set<string>;
+  /** 本进程前的信任代理跳数：0 = 直连取 socket 地址；N ≥ 1 = 取 XFF 右起第 N 个。 */
+  trustedHops: number;
+}
+
+const DIRECT_CHANNEL = "remote";
+const DEFAULT_TRUSTED_HOPS = 1;
+
+/** 统一小写；去掉 IPv4-mapped IPv6 前缀与 /32 后缀。 */
+function normalizeIp(raw: string): string {
+  let ip = raw.trim().toLowerCase();
+  if (ip.startsWith("::ffff:")) ip = ip.slice("::ffff:".length);
+  if (ip.endsWith("/32")) ip = ip.slice(0, -"/32".length);
+  return ip;
+}
+
+export function loadAuthOptions(env: NodeJS.ProcessEnv = process.env): AuthOptions {
+  const hubIps = new Set(
+    (env.SCP_HUB_IPS ?? "")
+      .split(/[\s,]+/)
+      .map(normalizeIp)
+      .filter((s) => s.length > 0),
+  );
+  const hopsRaw = env.TRUSTED_PROXY_HOPS?.trim();
+  const parsed = hopsRaw ? Number.parseInt(hopsRaw, 10) : DEFAULT_TRUSTED_HOPS;
+  const trustedHops = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_TRUSTED_HOPS;
+  return { hubIps, trustedHops };
+}
+
+/**
+ * 取真实客户端 IP。XFF 形如 "client, proxy1, proxy2"：右侧 trustedHops 个条目
+ * 是我方信任设施（MSE 网关等）逐跳追加的，右起第 trustedHops 个即最后一个
+ * 可信来源地址；更左的条目均为客户端可伪造前缀，绝不采信。
+ */
+export function clientIp(req: IncomingMessage, trustedHops: number): string | null {
+  if (trustedHops <= 0) {
+    const addr = req.socket.remoteAddress;
+    return addr ? normalizeIp(addr) : null;
+  }
+  const header = req.headers["x-forwarded-for"];
+  const joined = Array.isArray(header) ? header.join(",") : (header ?? "");
+  const entries = joined
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  // 信任链不完整（XFF 条目数少于应有的信任跳数）：判 null，走 401。
+  if (entries.length < trustedHops) return null;
+  return normalizeIp(entries[entries.length - trustedHops]);
+}
+
+/** 判定请求走哪条通道；null = 无法鉴权（调用方应返回 401）。 */
+export function resolveLane(
+  req: IncomingMessage,
+  config: Config,
+  opts: AuthOptions,
+): LaneDecision | null {
+  const m = req.headers.authorization?.match(/^Bearer\s+(.+)$/i);
+  if (m) {
+    return { lane: "direct", token: m[1].trim(), channel: DIRECT_CHANNEL };
+  }
+  const ip = clientIp(req, opts.trustedHops);
+  if (ip && opts.hubIps.has(ip)) {
+    return { lane: "hub", token: config.token, channel: config.channel };
+  }
+  return null;
+}

--- a/packages/mcp/src/http-auth.ts
+++ b/packages/mcp/src/http-auth.ts
@@ -1,16 +1,22 @@
-// 双通道鉴权判定器（sciverse-console: docs/plans/2026-05-19-scp-mcp-http-transport.md §8.2）：
+// HTTP 入口鉴权判定器（通用机制，不含部署方专有概念；SciVerse 托管部署的
+// 具体取值见 sciverse-console: docs/plans/2026-05-19-scp-mcp-http-transport.md §8）：
 //   direct 通道：Authorization: Bearer <token> → 原样透传下游，channel = "remote"
-//   hub 通道：来源 IP ∈ SCP_HUB_IPS（信任跳 XFF 判定）→ 使用部署内置 token 代调
+//   trusted 通道：来源 IP ∈ SCIVERSE_MCP_TRUSTED_IPS → 使用进程内置 token 代调
 //   两者皆无 → 调用方返回 401
 //
 // Authorization 优先于 IP：自带 token 是比来源 IP 更明确的身份声明，且计费归属
-// 到调用方自己；Hub 将来若支持配转发 header，可无缝升级为自带 token。
-// 判定器刻意独立成模块：替换 hub 分支即可切换判定策略，透传通道不动。
+// 到调用方自己；可信通道的调用方将来若能自带 token，可无缝迁移，判定器不动。
+//
+// 来源 IP 的取得遵循「先验对端，再信转发头」：仅当 TCP 对端 ∈
+// SCIVERSE_MCP_TRUSTED_PROXIES（CIDR 列表）时才解析 X-Forwarded-For（取右起第
+// SCIVERSE_MCP_TRUSTED_PROXY_HOPS 个条目——右侧条目由信任设施逐跳追加，更左的
+// 均为客户端可伪造前缀）。默认不信任任何代理：不显式声明代理网段，转发头
+// 永不采信，绕过网关直连（如集群内工作负载）伪造 XFF 只会以自身地址参与判定。
 import type { IncomingMessage } from "node:http";
 
 import type { Config } from "./config.js";
 
-export type Lane = "hub" | "direct";
+export type Lane = "trusted" | "direct";
 
 export interface LaneDecision {
   lane: Lane;
@@ -18,10 +24,18 @@ export interface LaneDecision {
   channel: string;
 }
 
+/** 信任代理集合：IPv4 支持 CIDR；其余条目（IPv6 等）精确匹配。 */
+export interface TrustedProxies {
+  v4: { base: number; bits: number }[];
+  exact: Set<string>;
+}
+
 export interface AuthOptions {
-  /** SCP Hub 出口 IP（精确匹配，已归一化）。空集 = hub 通道关闭。 */
-  hubIps: Set<string>;
-  /** 本进程前的信任代理跳数：0 = 直连取 socket 地址；N ≥ 1 = 取 XFF 右起第 N 个。 */
+  /** 可信来源 IP（精确匹配，已归一化）。空集 = trusted 通道关闭。 */
+  trustedIps: Set<string>;
+  /** 信任代理网段：TCP 对端命中才解析 XFF。空 = 转发头永不采信。 */
+  trustedProxies: TrustedProxies;
+  /** 解析 XFF 时取右起第几个条目（≥1）；需与代理真实跳数一致。 */
   trustedHops: number;
 }
 
@@ -36,38 +50,76 @@ function normalizeIp(raw: string): string {
   return ip;
 }
 
-export function loadAuthOptions(env: NodeJS.ProcessEnv = process.env): AuthOptions {
-  const hubIps = new Set(
-    (env.SCP_HUB_IPS ?? "")
-      .split(/[\s,]+/)
-      .map(normalizeIp)
-      .filter((s) => s.length > 0),
-  );
-  const hopsRaw = env.TRUSTED_PROXY_HOPS?.trim();
-  const parsed = hopsRaw ? Number.parseInt(hopsRaw, 10) : DEFAULT_TRUSTED_HOPS;
-  const trustedHops = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_TRUSTED_HOPS;
-  return { hubIps, trustedHops };
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let v = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const n = Number(p);
+    if (n > 255) return null;
+    v = ((v << 8) | n) >>> 0;
+  }
+  return v;
 }
 
-/**
- * 取真实客户端 IP。XFF 形如 "client, proxy1, proxy2"：右侧 trustedHops 个条目
- * 是我方信任设施（MSE 网关等）逐跳追加的，右起第 trustedHops 个即最后一个
- * 可信来源地址；更左的条目均为客户端可伪造前缀，绝不采信。
- */
-export function clientIp(req: IncomingMessage, trustedHops: number): string | null {
-  if (trustedHops <= 0) {
-    const addr = req.socket.remoteAddress;
-    return addr ? normalizeIp(addr) : null;
+/** 解析逗号/空白分隔的代理列表；IPv4 条目可带 /bits，非法 bits 的条目降级为精确匹配。 */
+export function parseTrustedProxies(raw: string | undefined): TrustedProxies {
+  const out: TrustedProxies = { v4: [], exact: new Set() };
+  for (const entry of (raw ?? "").split(/[\s,]+/)) {
+    if (!entry.trim()) continue;
+    const [ipPart, bitsPart] = entry.trim().toLowerCase().split("/");
+    const ip = normalizeIp(ipPart);
+    const asV4 = ipv4ToInt(ip);
+    if (asV4 !== null) {
+      const bits = bitsPart === undefined ? 32 : Number.parseInt(bitsPart, 10);
+      if (Number.isFinite(bits) && bits >= 0 && bits <= 32) {
+        out.v4.push({ base: asV4, bits });
+        continue;
+      }
+    }
+    out.exact.add(ip);
   }
+  return out;
+}
+
+function isTrustedProxy(ip: string, proxies: TrustedProxies): boolean {
+  if (proxies.exact.has(ip)) return true;
+  const v4 = ipv4ToInt(ip);
+  if (v4 === null) return false;
+  // bits=0（0.0.0.0/0）需特判：JS 位移量按 mod 32 取，>>> 32 等价 >>> 0。
+  return proxies.v4.some(({ base, bits }) => (bits === 0 ? true : ((v4 ^ base) >>> (32 - bits)) === 0));
+}
+
+/** 取参与鉴权判定的来源 IP；null = 信任链不完整（调用方应 401，fail-closed）。 */
+export function clientIp(req: IncomingMessage, opts: AuthOptions): string | null {
+  const peer = req.socket.remoteAddress ? normalizeIp(req.socket.remoteAddress) : null;
+  if (!peer) return null;
+  // 对端不是信任代理：XFF 一律不采信，直接用 socket 地址。
+  if (!isTrustedProxy(peer, opts.trustedProxies)) return peer;
+  const hops = Math.max(1, Math.floor(opts.trustedHops));
   const header = req.headers["x-forwarded-for"];
   const joined = Array.isArray(header) ? header.join(",") : (header ?? "");
   const entries = joined
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
-  // 信任链不完整（XFF 条目数少于应有的信任跳数）：判 null，走 401。
-  if (entries.length < trustedHops) return null;
-  return normalizeIp(entries[entries.length - trustedHops]);
+  if (entries.length < hops) return null;
+  return normalizeIp(entries[entries.length - hops]);
+}
+
+export function loadAuthOptions(env: NodeJS.ProcessEnv = process.env): AuthOptions {
+  const trustedIps = new Set(
+    (env.SCIVERSE_MCP_TRUSTED_IPS ?? "")
+      .split(/[\s,]+/)
+      .map(normalizeIp)
+      .filter((s) => s.length > 0),
+  );
+  const trustedProxies = parseTrustedProxies(env.SCIVERSE_MCP_TRUSTED_PROXIES);
+  const hopsRaw = env.SCIVERSE_MCP_TRUSTED_PROXY_HOPS?.trim();
+  const parsed = hopsRaw ? Number.parseInt(hopsRaw, 10) : DEFAULT_TRUSTED_HOPS;
+  const trustedHops = Number.isFinite(parsed) && parsed >= 1 ? parsed : DEFAULT_TRUSTED_HOPS;
+  return { trustedIps, trustedProxies, trustedHops };
 }
 
 /** 判定请求走哪条通道；null = 无法鉴权（调用方应返回 401）。 */
@@ -80,9 +132,9 @@ export function resolveLane(
   if (m) {
     return { lane: "direct", token: m[1].trim(), channel: DIRECT_CHANNEL };
   }
-  const ip = clientIp(req, opts.trustedHops);
-  if (ip && opts.hubIps.has(ip)) {
-    return { lane: "hub", token: config.token, channel: config.channel };
+  const ip = clientIp(req, opts);
+  if (ip && opts.trustedIps.has(ip)) {
+    return { lane: "trusted", token: config.token, channel: config.channel };
   }
   return null;
 }

--- a/packages/mcp/tests/cli-http.test.ts
+++ b/packages/mcp/tests/cli-http.test.ts
@@ -9,6 +9,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import { startHttpServer, type HttpServerHandle } from "../src/cli-http.js";
+import { parseTrustedProxies } from "../src/http-auth.js";
 import type { Config } from "../src/config.js";
 
 const CONFIG: Config = {
@@ -17,9 +18,13 @@ const CONFIG: Config = {
   channel: "scp",
 };
 
-// 测试用鉴权配置：把本地回环当 SCP Hub 出口 IP（trustedHops=0 → 直接取 socket 地址），
-// 让既有 e2e 用例走 hub 通道、无需携带 Authorization。
-const HUB_LOCAL_AUTH = { hubIps: new Set(["127.0.0.1", "::1"]), trustedHops: 0 };
+// 测试用鉴权配置：把本地回环列为可信 IP（不配信任代理 → XFF 不采信，直接取 socket 地址），
+// 让既有 e2e 用例走 trusted 通道、无需携带 Authorization。
+const LOCAL_TRUSTED_AUTH = {
+  trustedIps: new Set(["127.0.0.1", "::1"]),
+  trustedProxies: parseTrustedProxies(""),
+  trustedHops: 1,
+};
 
 // 业务层 fetch (tools.ts 内的 fetch) 用 vi.stubGlobal mock；
 // 但 MCP client 自己也走 global fetch 访问本地 HTTP server——
@@ -53,20 +58,20 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("/healthz 返回 200 + 'ok'", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: LOCAL_TRUSTED_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("ok");
   });
 
   it("未知路径返回 404", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: LOCAL_TRUSTED_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/nope`);
     expect(res.status).toBe(404);
   });
 
   it("完整跑通 initialize → tools/list → tools/call (semantic_search)", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: LOCAL_TRUSTED_AUTH });
 
     // mock 下游 sciverse API：返回一组 fake hits
     stubUpstreamFetch(async (url) => {
@@ -109,7 +114,7 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("大 payload（~500KB）不截断", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: LOCAL_TRUSTED_AUTH });
 
     // 生成 ~500KB 的 ASCII 字符串，包到 JSON 里当 hits 内容
     const bigText = "A".repeat(500 * 1024);
@@ -143,7 +148,7 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("无 session id 且非 initialize 时返回 400", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: LOCAL_TRUSTED_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
@@ -156,8 +161,8 @@ describe("cli-http: Streamable-HTTP transport", () => {
 });
 
 // —— Phase 1.5 鉴权双通道（http-auth）——
-// 判定规则：Authorization: Bearer 优先（透传，channel=remote）；
-// 否则信任跳 XFF/socket IP ∈ hubIps（内置 token，channel 沿用配置）；两者皆无 → 401。
+// 判定规则：Authorization: Bearer 优先（透传，channel=remote）；否则来源 IP ∈ trustedIps
+// 走内置 token（XFF 仅在 TCP 对端命中 trustedProxies 时采信）；两者皆无 → 401。
 describe("cli-http: 鉴权双通道", () => {
   let handle: HttpServerHandle | undefined;
 
@@ -196,7 +201,7 @@ describe("cli-http: 鉴权双通道", () => {
     handle = await startHttpServer(CONFIG, {
       port: 0,
       host: "127.0.0.1",
-      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+      auth: { trustedIps: new Set<string>(), trustedProxies: parseTrustedProxies(""), trustedHops: 1 },
     });
     const res = await rawInit(handle.port);
     expect(res.status).toBe(401);
@@ -209,7 +214,7 @@ describe("cli-http: 鉴权双通道", () => {
     handle = await startHttpServer(CONFIG, {
       port: 0,
       host: "127.0.0.1",
-      auth: { hubIps: new Set(["10.0.0.9"]), trustedHops: 1 },
+      auth: { trustedIps: new Set(["10.0.0.9"]), trustedProxies: parseTrustedProxies("127.0.0.0/8, ::1"), trustedHops: 1 },
     });
     // 伪造者把 hub IP 放在前缀，信任网关追加了真实来源 6.6.6.6 → 取 6.6.6.6 → 拒绝
     const spoofed = await rawInit(handle.port, { "x-forwarded-for": "10.0.0.9, 6.6.6.6" });
@@ -220,11 +225,22 @@ describe("cli-http: 鉴权双通道", () => {
     expect(legit.headers.get("mcp-session-id")).toBeTruthy();
   });
 
-  it("hub 通道：下游收到内置 token，channel 沿用配置（scp）", async () => {
+  it("非信任对端送来的 XFF 不采信（集群内直连伪造被挡）", async () => {
     handle = await startHttpServer(CONFIG, {
       port: 0,
       host: "127.0.0.1",
-      auth: HUB_LOCAL_AUTH,
+      // trustedProxies 为空：本地直连不是信任代理，XFF 整条忽略，按 socket 地址判定
+      auth: { trustedIps: new Set(["10.0.0.9"]), trustedProxies: parseTrustedProxies(""), trustedHops: 1 },
+    });
+    const res = await rawInit(handle.port, { "x-forwarded-for": "10.0.0.9" });
+    expect(res.status).toBe(401);
+  });
+
+  it("trusted 通道：下游收到内置 token，channel 沿用配置（scp）", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: LOCAL_TRUSTED_AUTH,
     });
     let upstreamHeaders: Record<string, string> = {};
     stubUpstreamFetch(async (_url, init) => {
@@ -249,7 +265,7 @@ describe("cli-http: 鉴权双通道", () => {
     handle = await startHttpServer(CONFIG, {
       port: 0,
       host: "127.0.0.1",
-      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+      auth: { trustedIps: new Set<string>(), trustedProxies: parseTrustedProxies(""), trustedHops: 1 },
     });
     let upstreamHeaders: Record<string, string> = {};
     stubUpstreamFetch(async (_url, init) => {
@@ -275,7 +291,7 @@ describe("cli-http: 鉴权双通道", () => {
     handle = await startHttpServer(CONFIG, {
       port: 0,
       host: "127.0.0.1",
-      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+      auth: { trustedIps: new Set<string>(), trustedProxies: parseTrustedProxies(""), trustedHops: 1 },
     });
     const init = await rawInit(handle.port, { authorization: "Bearer tok-a" });
     expect(init.status).toBe(200);

--- a/packages/mcp/tests/cli-http.test.ts
+++ b/packages/mcp/tests/cli-http.test.ts
@@ -17,6 +17,10 @@ const CONFIG: Config = {
   channel: "scp",
 };
 
+// 测试用鉴权配置：把本地回环当 SCP Hub 出口 IP（trustedHops=0 → 直接取 socket 地址），
+// 让既有 e2e 用例走 hub 通道、无需携带 Authorization。
+const HUB_LOCAL_AUTH = { hubIps: new Set(["127.0.0.1", "::1"]), trustedHops: 0 };
+
 // 业务层 fetch (tools.ts 内的 fetch) 用 vi.stubGlobal mock；
 // 但 MCP client 自己也走 global fetch 访问本地 HTTP server——
 // 解决办法：mock 函数里只拦截 sciverse.space 域，其余 fallthrough 到原始 fetch。
@@ -49,20 +53,20 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("/healthz 返回 200 + 'ok'", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1" });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/healthz`);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("ok");
   });
 
   it("未知路径返回 404", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1" });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/nope`);
     expect(res.status).toBe(404);
   });
 
   it("完整跑通 initialize → tools/list → tools/call (semantic_search)", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1" });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
 
     // mock 下游 sciverse API：返回一组 fake hits
     stubUpstreamFetch(async (url) => {
@@ -105,7 +109,7 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("大 payload（~500KB）不截断", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1" });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
 
     // 生成 ~500KB 的 ASCII 字符串，包到 JSON 里当 hits 内容
     const bigText = "A".repeat(500 * 1024);
@@ -139,7 +143,7 @@ describe("cli-http: Streamable-HTTP transport", () => {
   });
 
   it("无 session id 且非 initialize 时返回 400", async () => {
-    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1" });
+    handle = await startHttpServer(CONFIG, { port: 0, host: "127.0.0.1", auth: HUB_LOCAL_AUTH });
     const res = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
       method: "POST",
       headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
@@ -148,5 +152,159 @@ describe("cli-http: Streamable-HTTP transport", () => {
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body.error).toBeDefined();
+  });
+});
+
+// —— Phase 1.5 鉴权双通道（http-auth）——
+// 判定规则：Authorization: Bearer 优先（透传，channel=remote）；
+// 否则信任跳 XFF/socket IP ∈ hubIps（内置 token，channel 沿用配置）；两者皆无 → 401。
+describe("cli-http: 鉴权双通道", () => {
+  let handle: HttpServerHandle | undefined;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.close();
+      handle = undefined;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  const INIT_BODY = JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "test", version: "0.0.0" },
+    },
+  });
+
+  function rawInit(port: number, headers: Record<string, string> = {}): Promise<Response> {
+    return fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        ...headers,
+      },
+      body: INIT_BODY,
+    });
+  }
+
+  it("匿名请求（非 hub IP、无 Authorization）返回 401 + WWW-Authenticate", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+    });
+    const res = await rawInit(handle.port);
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toBe("Bearer");
+    const body = await res.json();
+    expect(body.error.message).toContain("Unauthorized");
+  });
+
+  it("XFF 伪造前缀不生效：只取右起第 trustedHops 个条目", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: { hubIps: new Set(["10.0.0.9"]), trustedHops: 1 },
+    });
+    // 伪造者把 hub IP 放在前缀，信任网关追加了真实来源 6.6.6.6 → 取 6.6.6.6 → 拒绝
+    const spoofed = await rawInit(handle.port, { "x-forwarded-for": "10.0.0.9, 6.6.6.6" });
+    expect(spoofed.status).toBe(401);
+    // 信任网关追加的正是 hub IP → 放行
+    const legit = await rawInit(handle.port, { "x-forwarded-for": "10.0.0.9" });
+    expect(legit.status).toBe(200);
+    expect(legit.headers.get("mcp-session-id")).toBeTruthy();
+  });
+
+  it("hub 通道：下游收到内置 token，channel 沿用配置（scp）", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: HUB_LOCAL_AUTH,
+    });
+    let upstreamHeaders: Record<string, string> = {};
+    stubUpstreamFetch(async (_url, init) => {
+      upstreamHeaders = (init.headers ?? {}) as Record<string, string>;
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = new Client({ name: "t", version: "0.0.0" }, { capabilities: {} });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${handle.port}/mcp`),
+    );
+    await client.connect(transport);
+    await client.callTool({ name: "semantic_search", arguments: { query: "x" } });
+    expect(upstreamHeaders["authorization"]).toBe("Bearer sv-test");
+    expect(upstreamHeaders["x-sciverse-source"]).toMatch(/-scp$/);
+    await client.close();
+  });
+
+  it("direct 通道：Authorization 原样透传，channel=remote", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+    });
+    let upstreamHeaders: Record<string, string> = {};
+    stubUpstreamFetch(async (_url, init) => {
+      upstreamHeaders = (init.headers ?? {}) as Record<string, string>;
+      return new Response(JSON.stringify({ hits: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const client = new Client({ name: "t", version: "0.0.0" }, { capabilities: {} });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${handle.port}/mcp`),
+      { requestInit: { headers: { authorization: "Bearer user-tok-123" } } },
+    );
+    await client.connect(transport);
+    await client.callTool({ name: "semantic_search", arguments: { query: "x" } });
+    expect(upstreamHeaders["authorization"]).toBe("Bearer user-tok-123");
+    expect(upstreamHeaders["x-sciverse-source"]).toMatch(/-remote$/);
+    await client.close();
+  });
+
+  it("session 与凭据绑定：换 token 复用 session 返回 401", async () => {
+    handle = await startHttpServer(CONFIG, {
+      port: 0,
+      host: "127.0.0.1",
+      auth: { hubIps: new Set<string>(), trustedHops: 0 },
+    });
+    const init = await rawInit(handle.port, { authorization: "Bearer tok-a" });
+    expect(init.status).toBe(200);
+    const sid = init.headers.get("mcp-session-id");
+    expect(sid).toBeTruthy();
+
+    const listBody = JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    const hijack = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: "Bearer tok-b",
+        "mcp-session-id": sid!,
+      },
+      body: listBody,
+    });
+    expect(hijack.status).toBe(401);
+
+    const legit = await fetch(`http://127.0.0.1:${handle.port}/mcp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        authorization: "Bearer tok-a",
+        "mcp-session-id": sid!,
+      },
+      body: listBody,
+    });
+    expect(legit.status).toBe(200);
   });
 });


### PR DESCRIPTION
## 背景

`sciverse-mcp-http` 入口此前不做任何鉴权：任何能访问端口的调用方都可匿名使用部署方的内置 token，且应用层没有请求日志。

## 变更

**鉴权双通道**（新增 `src/http-auth.ts`，请求进入 MCP 协议层之前判定）：

1. `Authorization: Bearer <token>` → **透传通道**：token 原样透传下游（本进程不验，鉴权权威是后端 API），`X-Sciverse-Source` channel 标记为 `remote`，计费归属调用方
2. 来源 IP ∈ `SCIVERSE_MCP_TRUSTED_IPS` → **可信通道**：使用进程内置 token 代调，channel 沿用配置
3. 两者皆无 → `401` + `WWW-Authenticate: Bearer`

**信任代理门**：仅当 TCP 对端命中 `SCIVERSE_MCP_TRUSTED_PROXIES`（CIDR 列表）时才解析 `X-Forwarded-For`（取右起第 `SCIVERSE_MCP_TRUSTED_PROXY_HOPS` 个条目）；默认不信任任何代理，转发头永不采信——封堵绕过网关直连伪造 XFF 冒用可信通道的路径。

**session 凭据绑定**：session 与首次判定的通道/token 绑定，后续请求凭据不一致返回 401。

**请求日志**：每个 `/mcp` 请求向 stdout 写一行 `method/rpc/lane/session/status/dur_ms`，恒不含 token；`/healthz` 不鉴权、不记日志。

## 行为变化（需在发版说明注明）

- `sciverse-mcp-http` 从匿名可用改为**默认 401**；本地自用可配 `SCIVERSE_MCP_TRUSTED_IPS=127.0.0.1` 恢复免 token
- stdio 入口（`sciverse-mcp`）零影响

## 测试

43/43 通过（`packages/mcp` vitest + tsc --noEmit），新增覆盖：匿名 401、XFF 伪造前缀拒绝、非信任对端 XFF 整条忽略、双通道下游 header 断言、session 劫持 401。

🤖 Generated with [Claude Code](https://claude.com/claude-code)