### PR TITLE
fix: top_k 上限声明与服务端实际对齐（30 → 100，注明单路有效约 50）

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ const resp = await openai.chat.completions.create({
 });
 ```
 
+**LangChain (Python):**
+
+`dist/langchain_tools.py` ships `BaseTool` subclasses generated from the same OpenAPI
+spec. Bind them to an `AgentToolsClient` with `build_tools` — the client carries the
+credentials and translates arguments the raw endpoints do not accept (`mode`, for one,
+is ignored upstream, so a hand-rolled HTTP call makes `quality` behave like `balanced`).
+
+```python
+from langchain_tools import build_tools   # from dist/langchain_tools.py
+from sciverse import AgentToolsClient
+
+async with AgentToolsClient() as client:
+    tools = build_tools(client)           # all 6 tools, bound
+    hits = await tools[1].ainvoke({"query": "Transformer attention", "mode": "quality"})
+```
+
+The tools are async-only: drive them with `ainvoke()` or an async agent executor.
+
 End-to-end examples (full tool-calling loop) live in [`examples/`](./examples/):
 
 **Direct SDK use (you own the tool-calling loop):**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,6 +193,23 @@ const resp = await openai.chat.completions.create({
 });
 ```
 
+**LangChain（Python）：**
+
+`dist/langchain_tools.py` 是由同一份 OpenAPI 生成的 `BaseTool` 子类。用 `build_tools`
+绑定 `AgentToolsClient` 后使用——client 持有凭据，并负责翻译裸接口不认识的参数
+（例如 `mode`，上游会静默丢弃，自己拼 HTTP 会让 `quality` 实际跑成 `balanced`）。
+
+```python
+from langchain_tools import build_tools   # 来自 dist/langchain_tools.py
+from sciverse import AgentToolsClient
+
+async with AgentToolsClient() as client:
+    tools = build_tools(client)           # 6 个工具，均已绑定
+    hits = await tools[1].ainvoke({"query": "Transformer attention", "mode": "quality"})
+```
+
+这些工具仅支持异步：用 `ainvoke()` 或异步 agent executor 驱动。
+
 完整端到端示例（含 tool 调用回环）见 [`examples/`](./examples/)：
 
 **SDK 直接调用（自己写 tool calling 回环）：**

--- a/clawhub/manifest.json
+++ b/clawhub/manifest.json
@@ -192,7 +192,7 @@
             "default": 10,
             "minimum": 1,
             "maximum": 100,
-            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
           },
           "source_types": {
             "type": "array",

--- a/clawhub/manifest.json
+++ b/clawhub/manifest.json
@@ -191,7 +191,8 @@
             "type": "integer",
             "default": 10,
             "minimum": 1,
-            "maximum": 30
+            "maximum": 100,
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
           },
           "source_types": {
             "type": "array",

--- a/clawhub/scripts/semantic_search.mjs
+++ b/clawhub/scripts/semantic_search.mjs
@@ -2,10 +2,34 @@
 // semantic_search — POST /agentic-search
 import { callSciverse, readJsonArg } from "./_common.mjs";
 
+// 上游 agentic-search（Go 服务）没有 mode 字段，未知字段会被静默丢弃，
+// 所以 mode 必须在这里翻译为上游真实参数 retrieval / sub_queries
+// （与 packages/typescript/src/client.ts 的 SEMANTIC_MODE_MAP 保持一致）。
+const MODE_MAP = {
+  fast: { retrieval: "es" },
+  balanced: { retrieval: "hybrid" },
+  quality: { retrieval: "hybrid", sub_queries: 3 },
+};
+
 const args = readJsonArg();
 if (!args.query) {
   console.error("[semantic_search] 必须提供 query 字段。");
   process.exit(2);
 }
-const result = await callSciverse("POST", "/agentic-search", { body: args });
+
+const { mode, ...rest } = args;
+let body = rest;
+if (mode !== undefined && mode !== null) {
+  const mapped = MODE_MAP[mode];
+  if (!mapped) {
+    console.error(
+      `[semantic_search] mode 必须是 ${Object.keys(MODE_MAP).join(" / ")} 之一，收到 ${JSON.stringify(mode)}。`,
+    );
+    process.exit(2);
+  }
+  // 显式传入的 retrieval / sub_queries 优先于 mode 映射。
+  body = { ...mapped, ...rest };
+}
+
+const result = await callSciverse("POST", "/agentic-search", { body });
 console.log(JSON.stringify(result));

--- a/dist/anthropic-tools.json
+++ b/dist/anthropic-tools.json
@@ -171,7 +171,7 @@
             "default": 10,
             "minimum": 1,
             "maximum": 100,
-            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
           },
           "source_types": {
             "type": "array",

--- a/dist/anthropic-tools.json
+++ b/dist/anthropic-tools.json
@@ -170,7 +170,8 @@
             "type": "integer",
             "default": 10,
             "minimum": 1,
-            "maximum": 30
+            "maximum": 100,
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
           },
           "source_types": {
             "type": "array",

--- a/dist/langchain_tools.py
+++ b/dist/langchain_tools.py
@@ -47,7 +47,7 @@ class SearchPapersTool(BaseTool):
 class SemanticSearchArgs(BaseModel):
     model_config = ConfigDict(extra='forbid')
     query: str = Field(..., description='自然语言查询，1-200 字最佳。')
-    top_k: int = Field(10, description='返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n')
+    top_k: int = Field(10, description='返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n')
     source_types: list[str] | None = Field(None, description='')
     mode: str = Field('balanced', description='fast = 仅关键词召回 (~200ms)；balanced = 混合检索 (~600ms)；quality = LLM 改写 + 混合 (~2-4s)。\n')
 

--- a/dist/langchain_tools.py
+++ b/dist/langchain_tools.py
@@ -8,6 +8,19 @@ from pydantic import BaseModel, ConfigDict, Field
 
 TOOLS_VERSION = "0.11.1"
 
+_NO_CLIENT = (
+    "No Sciverse client bound. Build these tools with build_tools(client), passing a "
+    "sciverse.AgentToolsClient — it holds the credentials and translates arguments such "
+    "as `mode` into the parameters the API actually accepts."
+)
+
+# The Sciverse client is async-only, and calling asyncio.run() from inside a running
+# event loop raises. Async-only tools are a standard LangChain pattern: drive them with
+# ainvoke() / an async executor.
+_SYNC_UNSUPPORTED = (
+    "{name} is async-only. Use `await tool.ainvoke(...)` or an async agent executor."
+)
+
 
 class SearchPapersArgs(BaseModel):
     model_config = ConfigDict(extra='forbid')
@@ -36,12 +49,15 @@ class SearchPapersTool(BaseTool):
 返回：论文元数据列表，每条含 unique_id（始终存在）、doc_id（仅当有全文）、title、author、abstract、publication_venue_name_unified、publication_published_year 等。
 """
     args_schema: type[BaseModel] = SearchPapersArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.search_papers(**kwargs)
 
 
 class SemanticSearchArgs(BaseModel):
@@ -61,12 +77,15 @@ class SemanticSearchTool(BaseTool):
 典型链路：semantic_search → 选取 chunk → read_content(doc_id, offset)。
 """
     args_schema: type[BaseModel] = SemanticSearchArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.semantic_search(**kwargs)
 
 
 class ListCatalogArgs(BaseModel):
@@ -88,12 +107,15 @@ class ListCatalogTool(BaseTool):
 include_sample_values=true 时返回枚举值样本（OpenSearch terms agg，缓存 24h）。
 """
     args_schema: type[BaseModel] = ListCatalogArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.list_catalog(**kwargs)
 
 
 class ListPaperRelationsArgs(BaseModel):
@@ -118,12 +140,15 @@ search_papers 的 filters_advanced 传 references_unique_id 反查——可深�
 total_count 为库内命中数（不含指向库外论文的边），与论文自身 citation_count 可能有 ±1% 差异。
 """
     args_schema: type[BaseModel] = ListPaperRelationsArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.list_paper_relations(**kwargs)
 
 
 class ReadContentArgs(BaseModel):
@@ -140,12 +165,15 @@ class ReadContentTool(BaseTool):
 返回：UTF-8 文本片段、bytes_returned、next_offset、是否还有后续。
 """
     args_schema: type[BaseModel] = ReadContentArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.read_content(**kwargs)
 
 
 class GetResourceArgs(BaseModel):
@@ -163,10 +191,30 @@ agent 需要把图给用户看时调本接口。
 SDK / MCP server 包装层会做 base64 + mime 转换以便 agent 多模态使用。
 """
     args_schema: type[BaseModel] = GetResourceArgs
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.get_resource(**kwargs)
+
+
+
+TOOL_CLASSES: list[type[BaseTool]] = [SearchPapersTool, SemanticSearchTool, ListCatalogTool, ListPaperRelationsTool, ReadContentTool, GetResourceTool]
+
+
+def build_tools(client: Any) -> list[BaseTool]:
+    """Return every Sciverse tool bound to `client`, ready to hand to an agent.
+
+    `client` is a `sciverse.AgentToolsClient`. Bind through it rather than calling the
+    HTTP API yourself: it owns credentials, retries, and the argument translation the
+    raw endpoints do not perform (an unmapped `mode`, for one, is silently ignored
+    upstream, so `quality` would quietly behave like `balanced`).
+
+    The tools are async-only — drive them with `ainvoke()` or an async executor.
+    """
+    return [cls(client=client) for cls in TOOL_CLASSES]
 

--- a/dist/langchain_tools.py
+++ b/dist/langchain_tools.py
@@ -47,7 +47,7 @@ class SearchPapersTool(BaseTool):
 class SemanticSearchArgs(BaseModel):
     model_config = ConfigDict(extra='forbid')
     query: str = Field(..., description='自然语言查询，1-200 字最佳。')
-    top_k: int = Field(10, description='')
+    top_k: int = Field(10, description='返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n')
     source_types: list[str] | None = Field(None, description='')
     mode: str = Field('balanced', description='fast = 仅关键词召回 (~200ms)；balanced = 混合检索 (~600ms)；quality = LLM 改写 + 混合 (~2-4s)。\n')
 

--- a/dist/openai-tools.json
+++ b/dist/openai-tools.json
@@ -175,7 +175,8 @@
               "type": "integer",
               "default": 10,
               "minimum": 1,
-              "maximum": 30
+              "maximum": 100,
+              "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
             },
             "source_types": {
               "type": "array",

--- a/dist/openai-tools.json
+++ b/dist/openai-tools.json
@@ -176,7 +176,7 @@
               "default": 10,
               "minimum": 1,
               "maximum": 100,
-              "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+              "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
             },
             "source_types": {
               "type": "array",

--- a/generators/to_claude_skill.py
+++ b/generators/to_claude_skill.py
@@ -254,10 +254,10 @@ def generate_skill_md(openapi_path: Path) -> str:
         "  so `read_content(doc_id, ...)` will work; `false` means no fulltext or no permission.",
         "- **When a chunk looks promising but truncated**: `read_content(doc_id, offset)`",
         "  to expand. `read_content` returns `more: true` when more bytes are available.",
-        "- **Pagination**: `semantic_search` top_k allows up to 100, but fast/balanced",
-        "  modes recall a single path whose server-side fusion pool keeps ~50 — use",
-        "  `mode=quality` when you need more than ~50 hits. `search_papers` returns",
-        "  max 50 per page; use `page` to paginate.",
+        "- **Pagination**: `semantic_search` top_k allows up to 100, but `balanced`",
+        "  truncates to ~50 server-side — use `quality` (or `fast`) when you need more.",
+        "  At most ~3 chunks come back per paper, so a high top_k needs many distinct",
+        "  papers to be matched. `search_papers` returns max 50 per page; use `page`.",
         "",
     ])
 

--- a/generators/to_claude_skill.py
+++ b/generators/to_claude_skill.py
@@ -254,8 +254,10 @@ def generate_skill_md(openapi_path: Path) -> str:
         "  so `read_content(doc_id, ...)` will work; `false` means no fulltext or no permission.",
         "- **When a chunk looks promising but truncated**: `read_content(doc_id, offset)`",
         "  to expand. `read_content` returns `more: true` when more bytes are available.",
-        "- **Pagination**: max 30 hits per `semantic_search`, max 50 per `search_papers`",
-        "  page; use `page` to paginate.",
+        "- **Pagination**: `semantic_search` top_k allows up to 100, but fast/balanced",
+        "  modes recall a single path whose server-side fusion pool keeps ~50 — use",
+        "  `mode=quality` when you need more than ~50 hits. `search_papers` returns",
+        "  max 50 per page; use `page` to paginate.",
         "",
     ])
 

--- a/generators/to_langchain.py
+++ b/generators/to_langchain.py
@@ -15,6 +15,19 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field
 
 TOOLS_VERSION = "{version}"
+
+_NO_CLIENT = (
+    "No Sciverse client bound. Build these tools with build_tools(client), passing a "
+    "sciverse.AgentToolsClient — it holds the credentials and translates arguments such "
+    "as `mode` into the parameters the API actually accepts."
+)
+
+# The Sciverse client is async-only, and calling asyncio.run() from inside a running
+# event loop raises. Async-only tools are a standard LangChain pattern: drive them with
+# ainvoke() / an async executor.
+_SYNC_UNSUPPORTED = (
+    "{{name}} is async-only. Use `await tool.ainvoke(...)` or an async agent executor."
+)
 '''
 
 
@@ -69,12 +82,33 @@ class {class_name}(BaseTool):
     name: str = "{operation_id}"
     description: str = """{desc}"""
     args_schema: type[BaseModel] = {args_class}
+    client: Any = None
 
     def _run(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        raise NotImplementedError(_SYNC_UNSUPPORTED.format(name=self.name))
 
     async def _arun(self, **kwargs: Any) -> Any:
-        raise NotImplementedError("bind a client via .with_client(...)")
+        if self.client is None:
+            raise ValueError(_NO_CLIENT)
+        return await self.client.{operation_id}(**kwargs)
+'''
+
+
+FOOTER = '''
+TOOL_CLASSES: list[type[BaseTool]] = [{class_list}]
+
+
+def build_tools(client: Any) -> list[BaseTool]:
+    """Return every Sciverse tool bound to `client`, ready to hand to an agent.
+
+    `client` is a `sciverse.AgentToolsClient`. Bind through it rather than calling the
+    HTTP API yourself: it owns credentials, retries, and the argument translation the
+    raw endpoints do not perform (an unmapped `mode`, for one, is silently ignored
+    upstream, so `quality` would quietly behave like `balanced`).
+
+    The tools are async-only — drive them with `ainvoke()` or an async executor.
+    """
+    return [cls(client=client) for cls in TOOL_CLASSES]
 '''
 
 
@@ -82,11 +116,14 @@ def generate(openapi_path: Path) -> str:
     spec = load_openapi(openapi_path)
     version = spec["info"]["x-sciverse-tools-version"]
     out = [HEADER.format(version=version)]
+    class_names = []
     for _path, _method, op in iter_operations(spec):
         args_class = f"{_camel(op['operationId'])}Args"
         schema = get_request_schema(op, spec)
         out.append(_emit_args_model(args_class, schema))
         out.append(_emit_tool_class(op["operationId"], op.get("description", ""), args_class))
+        class_names.append(f"{_camel(op['operationId'])}Tool")
+    out.append(FOOTER.format(class_list=", ".join(class_names)))
     return "\n\n".join(out) + "\n"
 
 

--- a/generators/web_skill_assets/references/rag-and-content.md
+++ b/generators/web_skill_assets/references/rag-and-content.md
@@ -18,8 +18,9 @@ node scripts/semantic_search.mjs '{
 Common arguments:
 
 - `query`: required natural-language query.
-- `top_k`: number of chunks; maximum 100. In `fast`/`balanced` modes the server's
-  single-path fusion pool keeps ~50, so expect at most ~50 hits; use `quality` for more.
+- `top_k`: number of chunks; maximum 100. `balanced` truncates to ~50 server-side
+  regardless of `top_k`; `fast` and `quality` reach the requested `top_k`. At most
+  ~3 chunks are returned per paper.
 - `source_types`: optional `["web"]`, `["pdf"]`, or both.
 - `mode`: `fast`, `balanced`, or `quality`.
 

--- a/generators/web_skill_assets/references/rag-and-content.md
+++ b/generators/web_skill_assets/references/rag-and-content.md
@@ -18,7 +18,8 @@ node scripts/semantic_search.mjs '{
 Common arguments:
 
 - `query`: required natural-language query.
-- `top_k`: number of chunks; maximum 30.
+- `top_k`: number of chunks; maximum 100. In `fast`/`balanced` modes the server's
+  single-path fusion pool keeps ~50, so expect at most ~50 hits; use `quality` for more.
 - `source_types`: optional `["web"]`, `["pdf"]`, or both.
 - `mode`: `fast`, `balanced`, or `quality`.
 

--- a/generators/web_skill_assets/scripts/semantic_search.mjs
+++ b/generators/web_skill_assets/scripts/semantic_search.mjs
@@ -2,10 +2,34 @@
 // semantic_search — POST /agentic-search
 import { callSciverse, readJsonArg } from "./_common.mjs";
 
+// 上游 agentic-search（Go 服务）没有 mode 字段，未知字段会被静默丢弃，
+// 所以 mode 必须在这里翻译为上游真实参数 retrieval / sub_queries
+// （与 packages/typescript/src/client.ts 的 SEMANTIC_MODE_MAP 保持一致）。
+const MODE_MAP = {
+  fast: { retrieval: "es" },
+  balanced: { retrieval: "hybrid" },
+  quality: { retrieval: "hybrid", sub_queries: 3 },
+};
+
 const args = readJsonArg();
 if (!args.query) {
   console.error("[semantic_search] 必须提供 query 字段。");
   process.exit(2);
 }
-const result = await callSciverse("POST", "/agentic-search", { body: args });
+
+const { mode, ...rest } = args;
+let body = rest;
+if (mode !== undefined && mode !== null) {
+  const mapped = MODE_MAP[mode];
+  if (!mapped) {
+    console.error(
+      `[semantic_search] mode 必须是 ${Object.keys(MODE_MAP).join(" / ")} 之一，收到 ${JSON.stringify(mode)}。`,
+    );
+    process.exit(2);
+  }
+  // 显式传入的 retrieval / sub_queries 优先于 mode 映射。
+  body = { ...mapped, ...rest };
+}
+
+const result = await callSciverse("POST", "/agentic-search", { body });
 console.log(JSON.stringify(result));

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -529,7 +529,11 @@ components:
           type: integer
           default: 10
           minimum: 1
-          maximum: 30
+          maximum: 100
+          description: |
+            返回命中条数上限，合法 1-100（服务端校验，超出报 400）。
+            fast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；
+            需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。
         source_types:
           type: array
           items: { type: string, enum: [web, pdf] }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -532,8 +532,9 @@ components:
           maximum: 100
           description: |
             返回命中条数上限，合法 1-100（服务端校验，超出报 400）。
-            fast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；
-            需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。
+            实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，
+            top_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。
+            另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。
         source_types:
           type: array
           items: { type: string, enum: [web, pdf] }

--- a/packages/python/src/sciverse/cli.py
+++ b/packages/python/src/sciverse/cli.py
@@ -285,8 +285,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sem.add_argument("query", help="自然语言查询（1-200 字最佳）")
     sem.add_argument("--top-k", type=int, default=10, dest="top_k",
-                     help="返回 chunk 数量，默认 10，上限 100（fast/balanced 单路召回实际至多约 50，"
-                          "更多命中用 --mode quality）")
+                     help="返回 chunk 数量，默认 10，上限 100（balanced 在服务端固定截到约 50，"
+                          "要更多请用 --mode quality 或 fast）")
     sem.add_argument("--mode", choices=["fast", "balanced", "quality"], default="balanced",
                      help="fast=纯关键词 (~200ms) / balanced=混合 (~600ms，默认) / quality=LLM 改写 (~2-4s)")
     sem.set_defaults(func=_cmd_semantic_search)

--- a/packages/python/src/sciverse/cli.py
+++ b/packages/python/src/sciverse/cli.py
@@ -285,7 +285,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sem.add_argument("query", help="自然语言查询（1-200 字最佳）")
     sem.add_argument("--top-k", type=int, default=10, dest="top_k",
-                     help="返回 chunk 数量，默认 10，上限 30")
+                     help="返回 chunk 数量，默认 10，上限 100（fast/balanced 单路召回实际至多约 50，"
+                          "更多命中用 --mode quality）")
     sem.add_argument("--mode", choices=["fast", "balanced", "quality"], default="balanced",
                      help="fast=纯关键词 (~200ms) / balanced=混合 (~600ms，默认) / quality=LLM 改写 (~2-4s)")
     sem.set_defaults(func=_cmd_semantic_search)

--- a/packages/python/src/sciverse/tools.py
+++ b/packages/python/src/sciverse/tools.py
@@ -180,7 +180,7 @@ OPENAI_TOOLS = json.loads(r"""
             "default": 10,
             "minimum": 1,
             "maximum": 100,
-            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
           },
           "source_types": {
             "type": "array",
@@ -503,7 +503,7 @@ ANTHROPIC_TOOLS = json.loads(r"""
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
         },
         "source_types": {
           "type": "array",

--- a/packages/python/src/sciverse/tools.py
+++ b/packages/python/src/sciverse/tools.py
@@ -179,7 +179,8 @@ OPENAI_TOOLS = json.loads(r"""
             "type": "integer",
             "default": 10,
             "minimum": 1,
-            "maximum": 30
+            "maximum": 100,
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
           },
           "source_types": {
             "type": "array",
@@ -501,7 +502,8 @@ ANTHROPIC_TOOLS = json.loads(r"""
           "type": "integer",
           "default": 10,
           "minimum": 1,
-          "maximum": 30
+          "maximum": 100,
+          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
         },
         "source_types": {
           "type": "array",

--- a/packages/python/src/sciverse/types.py
+++ b/packages/python/src/sciverse/types.py
@@ -190,7 +190,7 @@ class SemanticSearchRequest(BaseModel):
     )
     top_k: int | None = Field(
         10,
-        description="返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n",
+        description="返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n",
         ge=1,
         le=100,
     )

--- a/packages/python/src/sciverse/types.py
+++ b/packages/python/src/sciverse/types.py
@@ -188,7 +188,12 @@ class SemanticSearchRequest(BaseModel):
     query: str = Field(
         ..., description="自然语言查询，1-200 字最佳。", max_length=4096, min_length=1
     )
-    top_k: int | None = Field(10, ge=1, le=30)
+    top_k: int | None = Field(
+        10,
+        description="返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n",
+        ge=1,
+        le=100,
+    )
     source_types: list[SourceType] | None = None
     mode: Mode | None = Field(
         "balanced",

--- a/packages/typescript/src/tools.ts
+++ b/packages/typescript/src/tools.ts
@@ -176,7 +176,7 @@ export const OPENAI_TOOLS = [
             "default": 10,
             "minimum": 1,
             "maximum": 100,
-            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
           },
           "source_types": {
             "type": "array",
@@ -496,7 +496,7 @@ export const ANTHROPIC_TOOLS = [
           "default": 10,
           "minimum": 1,
           "maximum": 100,
-          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
+          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\n实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，\ntop_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。\n另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。\n"
         },
         "source_types": {
           "type": "array",

--- a/packages/typescript/src/tools.ts
+++ b/packages/typescript/src/tools.ts
@@ -175,7 +175,8 @@ export const OPENAI_TOOLS = [
             "type": "integer",
             "default": 10,
             "minimum": 1,
-            "maximum": 30
+            "maximum": 100,
+            "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
           },
           "source_types": {
             "type": "array",
@@ -494,7 +495,8 @@ export const ANTHROPIC_TOOLS = [
           "type": "integer",
           "default": 10,
           "minimum": 1,
-          "maximum": 30
+          "maximum": 100,
+          "description": "返回命中条数上限，合法 1-100（服务端校验，超出报 400）。\nfast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；\n需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。\n"
         },
         "source_types": {
           "type": "array",

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -213,7 +213,13 @@ export interface components {
     SemanticSearchRequest: {
       /** @description 自然语言查询，1-200 字最佳。 */
       query: string;
-      /** @default 10 */
+      /**
+       * @description 返回命中条数上限，合法 1-100（服务端校验，超出报 400）。
+       * fast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；
+       * 需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。
+       *
+       * @default 10
+       */
       top_k?: number;
       source_types?: ("web" | "pdf")[];
       /**

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -215,8 +215,9 @@ export interface components {
       query: string;
       /**
        * @description 返回命中条数上限，合法 1-100（服务端校验，超出报 400）。
-       * fast/balanced 为单路召回，服务端每路融合池当前保留约 50 条、实际返回至多约 50；
-       * 需要更多命中请用 quality 模式（多路子查询改写后合并，可超过 50）。
+       * 实际条数还受 mode 影响：balanced 单路混合召回在服务端固定截到约 50 条，
+       * top_k 超过 50 时多出的部分不会返回；fast 与 quality 可取到 top_k。
+       * 另外同一篇论文最多返回约 3 个 chunk，因此高 top_k 需要命中足够多的不同论文。
        *
        * @default 10
        */

--- a/skill-claude-code/SKILL.md
+++ b/skill-claude-code/SKILL.md
@@ -263,5 +263,7 @@ search_papers(collection="authors", filters_advanced=[{field: "orcid", value: "h
   so `read_content(doc_id, ...)` will work; `false` means no fulltext or no permission.
 - **When a chunk looks promising but truncated**: `read_content(doc_id, offset)`
   to expand. `read_content` returns `more: true` when more bytes are available.
-- **Pagination**: max 30 hits per `semantic_search`, max 50 per `search_papers`
-  page; use `page` to paginate.
+- **Pagination**: `semantic_search` top_k allows up to 100, but fast/balanced
+  modes recall a single path whose server-side fusion pool keeps ~50 — use
+  `mode=quality` when you need more than ~50 hits. `search_papers` returns
+  max 50 per page; use `page` to paginate.

--- a/skill-claude-code/SKILL.md
+++ b/skill-claude-code/SKILL.md
@@ -263,7 +263,7 @@ search_papers(collection="authors", filters_advanced=[{field: "orcid", value: "h
   so `read_content(doc_id, ...)` will work; `false` means no fulltext or no permission.
 - **When a chunk looks promising but truncated**: `read_content(doc_id, offset)`
   to expand. `read_content` returns `more: true` when more bytes are available.
-- **Pagination**: `semantic_search` top_k allows up to 100, but fast/balanced
-  modes recall a single path whose server-side fusion pool keeps ~50 — use
-  `mode=quality` when you need more than ~50 hits. `search_papers` returns
-  max 50 per page; use `page` to paginate.
+- **Pagination**: `semantic_search` top_k allows up to 100, but `balanced`
+  truncates to ~50 server-side — use `quality` (or `fast`) when you need more.
+  At most ~3 chunks come back per paper, so a high top_k needs many distinct
+  papers to be matched. `search_papers` returns max 50 per page; use `page`.

--- a/tests/test_to_langchain.py
+++ b/tests/test_to_langchain.py
@@ -35,3 +35,59 @@ def test_handles_multiline_description():
     compile(code, "<generated>", "exec")
     # 多行内容应该用 \n 表示，而不是字面 newline
     assert "line1\\nline2" in code
+
+
+def test_tools_dispatch_to_a_bound_client():
+    """生成的工具必须真能执行：绑定 client 后 _arun 按 operationId 分发。
+
+    历史问题：_run/_arun 一律抛 NotImplementedError，且提示指向从未实现的
+    .with_client()。工具形似可执行实则不可用，而 mode 之类需要 client 翻译的
+    参数会被使用者的裸 HTTP 调用静默丢弃。
+    """
+    code = generate(FIXTURE)
+    assert "client: Any = None" in code
+    assert "return await self.client.do_foo(**kwargs)" in code
+    assert "def build_tools(client: Any)" in code
+    assert "TOOL_CLASSES" in code
+    # 不再指向不存在的方法
+    assert "with_client" not in code
+
+
+def test_generated_module_executes_end_to_end():
+    """真正 import 生成的模块并跑一次调用，而不是只 compile。"""
+    import asyncio
+    import importlib.util
+    import sys
+
+    import pytest
+
+    pytest.importorskip("langchain_core")
+
+    code = generate(FIXTURE)
+    module = importlib.util.module_from_spec(
+        importlib.util.spec_from_loader("lc_tools_under_test", loader=None)
+    )
+    sys.modules["lc_tools_under_test"] = module
+    try:
+        exec(compile(code, "<generated>", "exec"), module.__dict__)
+
+        seen = []
+
+        class FakeClient:
+            async def do_foo(self, **kwargs):
+                seen.append(kwargs)
+                return {"ok": True}
+
+        tool = module.build_tools(FakeClient())[0]
+        assert asyncio.run(tool.ainvoke({"name": "x"})) == {"ok": True}
+        assert seen and seen[0]["name"] == "x"
+
+        # 未绑定 client 要给出可操作的错误，而不是 AttributeError
+        with pytest.raises(ValueError, match="build_tools"):
+            asyncio.run(module.DoFooTool().ainvoke({"name": "x"}))
+
+        # 同步入口明确指向异步用法
+        with pytest.raises(NotImplementedError, match="async-only"):
+            tool.invoke({"name": "x"})
+    finally:
+        sys.modules.pop("lc_tools_under_test", None)


### PR DESCRIPTION
openapi.yaml 原声明 maximum: 30，与服务端实际不符。经实际代码与线上
配置核查：agentic-search 校验上限为 configs/api.yaml max_top_k=100 （线上无 SEARCH_MAX_TOP_K 覆盖，超出报 400）；线上另设
SEARCH_RRF_PATH_TOPK=50，每子查询融合池保留 50 条——fast/balanced 单路召回实际返回至多约 50，quality 多路合并可超过。

改动：openapi.yaml top_k maximum 100 并补两层语义描述；CLI --top-k 帮助文本同步；to_claude_skill / web-skill 模板中硬编码的 max 30 改为 准确表述。派生产物经 scripts/build.sh 重新生成。

测试：pytest 36 通过，mcp vitest 46 通过，typescript tsc 无错。