### PR TITLE
fix(ci): 去掉 test.yml 重复的 workflow_dispatch（workflow 文件非法，Test 全挂）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-  workflow_dispatch:
 
 jobs:
   python:


### PR DESCRIPTION
PR #24 合入时 `on:` 块被文本合并叠加了两份 `workflow_dispatch`，GitHub 判定 workflow 文件 Invalid：`(Line: 12, Col: 3): 'workflow_dispatch' is already defined`——push/PR 的 Test 均无法触发（v0.13.0 发版后的 main 也没跑成 Test）。

保留带注释的那一份，删除重复项。已本地 `yaml.safe_load` 校验通过。

合入后建议手动 dispatch 一次 Test 验证 main 绿（这正是 workflow_dispatch 当初加进来的用途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)