### PR TITLE
docs: 清理 read_content 残留的 byte-range 措辞，统一为 Unicode 码点区间

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With these tools, you can easily empower your AI agents to search for academic p
 | `search_papers` | Structured metadata search over papers / authors / sources (set `collection`) |
 | `semantic_search` | Natural-language semantic search over passages (RAG) |
 | `list_paper_relations` | Paginate a paper's full citations / references / related works (by `unique_id`) |
-| `read_content` | Fetch a byte-range slice of the source document (extend RAG context) |
+| `read_content` | Fetch a character-range slice of the source document (offsets in Unicode code points; extend RAG context) |
 | `get_resource` | Fetch figure / table image bytes referenced inside `read_content` Markdown |
 
 All six tools share the same Bearer-Token authentication and are exposed identically through the Python SDK, the TypeScript SDK, the MCP server, the Claude Code skill, and the ClawHub skill. The canonical schema is [`openapi.yaml`](./openapi.yaml).

--- a/clawhub/README.md
+++ b/clawhub/README.md
@@ -26,7 +26,7 @@ export SCIVERSE_API_TOKEN=sv-xxx       # obtain from https://sciverse.space
 | `list_catalog` | Field introspection (call once to learn available fields + enum values) |
 | `search_papers` | Structured metadata search over papers / authors / sources (set `collection`) |
 | `semantic_search` | Natural-language semantic chunk retrieval (for RAG) |
-| `read_content` | Byte-range read of a paper's original text |
+| `read_content` | Character-range read of a paper's original text (offset/limit in Unicode code points) |
 | `get_resource` | Fetch figure / table image bytes referenced inside `read_content` Markdown |
 
 See `SKILL.md` for full agent-facing documentation.

--- a/clawhub/SKILL.md
+++ b/clawhub/SKILL.md
@@ -2,14 +2,14 @@
 name: sciverse-academic-retrieval
 slug: academic-retrieval
 version: 0.14.1
-description: Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and byte-range content reading. For agent workflows that need citation-grade scientific literature.
+description: Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and character-range content reading (offsets in Unicode code points). For agent workflows that need citation-grade scientific literature.
 license: Apache-2.0
 homepage: https://sciverse.space
 ---
 
 # academic-retrieval
 
-Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and byte-range content reading. For agent workflows that need citation-grade scientific literature.
+Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and character-range content reading (offsets in Unicode code points). For agent workflows that need citation-grade scientific literature.
 
 ## When to use
 

--- a/clawhub/manifest.json
+++ b/clawhub/manifest.json
@@ -2,7 +2,7 @@
   "name": "sciverse-academic-retrieval",
   "version": "0.14.1",
   "slug": "academic-retrieval",
-  "description": "Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and byte-range content reading. For agent workflows that need citation-grade scientific literature.",
+  "description": "Sciverse academic paper retrieval: structured metadata search, semantic chunk retrieval for RAG, and character-range content reading (offsets in Unicode code points). For agent workflows that need citation-grade scientific literature.",
   "runtime": "node>=18",
   "license": "Apache-2.0",
   "homepage": "https://sciverse.space",

--- a/generators/to_claude_skill.py
+++ b/generators/to_claude_skill.py
@@ -62,7 +62,7 @@ def generate_skill_md(openapi_path: Path) -> str:
         "Retrieval skill for the Sciverse open platform. Exposes six tools",
         "for working with scientific literature: field introspection,",
         "structured metadata search, semantic chunk retrieval for RAG,",
-        "citation / reference pagination, byte-range content reading, and",
+        "citation / reference pagination, character-range content reading, and",
         "figure / table image fetching.",
         "",
         "## When to use",

--- a/generators/to_clawhub_skill.py
+++ b/generators/to_clawhub_skill.py
@@ -22,7 +22,8 @@ SKILL_NAME = "sciverse-academic-retrieval"
 SKILL_SLUG = "academic-retrieval"
 SKILL_DESCRIPTION_EN = (
     "Sciverse academic paper retrieval: structured metadata search, semantic "
-    "chunk retrieval for RAG, and byte-range content reading. For agent "
+    "chunk retrieval for RAG, and character-range content reading (offsets in "
+    "Unicode code points). For agent "
     "workflows that need citation-grade scientific literature."
 )
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -90,7 +90,7 @@ default (`https://api.sciverse.space`).
 |---|---|
 | `search_papers` | Structured metadata search over papers / authors / sources (set `collection`) |
 | `semantic_search` | Natural-language semantic chunk retrieval (RAG) |
-| `read_content` | Byte-range read of original paper text |
+| `read_content` | Character-range read of original paper text (offset/limit in Unicode code points) |
 | `list_catalog` | Field introspection (returns all field names + enum sample values, agents should call this first to learn the schema) |
 | `get_resource` | Fetch a paper figure / table image; the server wraps the bytes as an MCP `image` content block (base64 + mimeType) so multimodal models (e.g. Claude) can read the figure inline |
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -125,7 +125,7 @@ await c.search_papers(
 # 2. Natural-language semantic search (vector + BM25 hybrid, returns chunks)
 await c.semantic_search(query="How does attention work?", top_k=10, mode="balanced")
 
-# 3. Byte-range read of original paper text
+# 3. Character-range (Unicode code point) read of original paper text
 #    (use doc_id + offset from semantic_search hits)
 await c.read_content(doc_id="p_xxx", offset=0, limit=8192)
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -7,7 +7,7 @@ retrieval tools (`searchPapers`, `semanticSearch`, `readContent`, `listCatalog`,
 `getResource`) behind one fetch-based client + ready-to-use `OPENAI_TOOLS` /
 `ANTHROPIC_TOOLS` constants for direct tool-calling.
 
-> Tools: `searchPapers` (structured metadata) / `semanticSearch` (semantic retrieval) / `readContent` (text byte-range) / `listCatalog` (field introspection) / `getResource` (paper figure binary).
+> Tools: `searchPapers` (structured metadata) / `semanticSearch` (semantic retrieval) / `readContent` (text by Unicode code-point range) / `listCatalog` (field introspection) / `getResource` (paper figure binary).
 >
 > 工具：`searchPapers`（结构化元数据）/ `semanticSearch`（语义检索）/ `readContent`（原文切片）/ `listCatalog`（字段 introspection）/ `getResource`（论文图片二进制）
 
@@ -83,7 +83,7 @@ await c.searchPapers({
 // 2. Natural-language semantic search (vector + BM25 hybrid, returns chunks)
 await c.semanticSearch({ query: "How does attention work?", top_k: 10, mode: "balanced" });
 
-// 3. Byte-range read of original paper text
+// 3. Character-range (Unicode code point) read of original paper text
 await c.readContent({ doc_id: "p_xxx", offset: 0, limit: 8192 });
 
 // 4. Schema introspection — call once to discover field names + enum values

--- a/skill-claude-code/SKILL.md
+++ b/skill-claude-code/SKILL.md
@@ -8,7 +8,7 @@ description: Use when the user needs academic paper retrieval — searching scie
 Retrieval skill for the Sciverse open platform. Exposes six tools
 for working with scientific literature: field introspection,
 structured metadata search, semantic chunk retrieval for RAG,
-citation / reference pagination, byte-range content reading, and
+citation / reference pagination, character-range content reading, and
 figure / table image fetching.
 
 ## When to use


### PR DESCRIPTION
## 背景

#29 把 `/content` 契约改为 Unicode 码点语义，但当时的替换只覆盖了「字节区间 / byte range / byte offset」写法，漏掉了连字符写法 **byte-range**：README、ClawHub skill 的 summary/description、Claude Code skill 的开头一句仍写着 "byte-range content reading"，与同一份文档里的工具描述自相矛盾。

## 变更

8 处源文件统一为 character-range（offsets in Unicode code points）：根 README、`clawhub/README.md`、三个 package README、`generators/to_clawhub_skill.py`、`generators/to_claude_skill.py`；`clawhub/SKILL.md` / `clawhub/manifest.json` / `skill-claude-code/SKILL.md` 经 `scripts/build.sh` 重建。纯文案，不涉及 schema。

## 注意

`docs:` 在 `.releaserc.yaml` 中为 patch release：合入会发 **0.14.2**（PyPI / npm / ClawHub 全部重发，ClawHub 会再进一次 LLM 复审）。如果不想为文案单发一版，可以等下一个 fix/feat 一起带出去，或把标题改成 `chore:` 再合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)